### PR TITLE
update reference data for  spe3 spe9 spe9group

### DIFF
--- a/spe3/opm-simulation-reference/flow/SPE3CASE1.PRT
+++ b/spe3/opm-simulation-reference/flow/SPE3CASE1.PRT
@@ -10,10 +10,10 @@
 Flow is a simulator for fully implicit three-phase black-oil flow, and is part of OPM.
 For more information visit: https://opm-project.org 
 
-Flow Version  =  2018.04-pre
+Flow Version  =  2018.10-pre
 System        =  opm-deb (Number of cores: 12, RAM: 32178.65 MB) 
 Architecture  =  Linux x86_64 (Release: 4.9.0-3-amd64, Version: #1 SMP Debian 4.9.30-2+deb9u2 (2017-06-26) )
-Simulation started on 23-04-2018 at 13:04:24 hrs
+Simulation started on 08-05-2018 at 08:08:42 hrs
 
 
 ===============Saturation Functions Diagnostics===============
@@ -70,7 +70,7 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step  0/175 at day 0/5475, date = 01-Jan-2015
 
 Time step 0, stepsize 1 days.
-Time step summary: well its =  1, newton its =  5, linearizations =  6 ( 0.013 sec), linear its =  17 ( 0.003 sec)
+Time step summary: well its =  1, newton its =  5, linearizations =  6 ( 0.012 sec), linear its =  17 ( 0.003 sec)
 
 Warning: Keyword 'BRS' is unhandled for output to file.
 
@@ -87,7 +87,7 @@ Warning: Keyword 'BOSAT' is unhandled for output to file.
 Warning: Keyword 'BRS' is unhandled for output to file.
 
 Time step 1, stepsize 3 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  12 ( 0.001 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  12 ( 0.001 sec)
 
 Warning: Keyword 'BRS' is unhandled for output to file.
 
@@ -138,11 +138,11 @@ Warning: Keyword 'BOSAT' is unhandled for output to file.
 Warning: Keyword 'BRS' is unhandled for output to file.
 
 Time step 4, stepsize 19.5714 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  18 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  18 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at   52.1428  Days *                SPE 3 - CASE 1                                          *
-  Report    1    22 Feb 2015  *                                             Flow  version 2018.04-pre  *
+  Report    1    22 Feb 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -189,11 +189,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step  1/175 at day 52.1428/5475, date = 22-Feb-2015
 
 Time step 0, stepsize 52.1428 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.010 sec), linear its =  22 ( 0.003 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  22 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at   104.286  Days *                SPE 3 - CASE 1                                          *
-  Report    2    15 Apr 2015  *                                             Flow  version 2018.04-pre  *
+  Report    2    15 Apr 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -240,11 +240,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step  2/175 at day 104.286/5475, date = 15-Apr-2015
 
 Time step 0, stepsize 52.1428 days.
-Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.015 sec), linear its =  34 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.008 sec), linear its =  34 ( 0.003 sec)
 
                               **************************************************************************
   Balance  at   156.429  Days *                SPE 3 - CASE 1                                          *
-  Report    3    06 Jun 2015  *                                             Flow  version 2018.04-pre  *
+  Report    3    06 Jun 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -291,11 +291,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step  3/175 at day 156.429/5475, date = 06-Jun-2015
 
 Time step 0, stepsize 52.1428 days.
-Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.013 sec), linear its =  30 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.007 sec), linear its =  30 ( 0.003 sec)
 
                               **************************************************************************
   Balance  at   208.571  Days *                SPE 3 - CASE 1                                          *
-  Report    4    28 Jul 2015  *                                             Flow  version 2018.04-pre  *
+  Report    4    28 Jul 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -346,7 +346,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at   260.714  Days *                SPE 3 - CASE 1                                          *
-  Report    5    18 Sep 2015  *                                             Flow  version 2018.04-pre  *
+  Report    5    18 Sep 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -397,7 +397,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at   312.857  Days *                SPE 3 - CASE 1                                          *
-  Report    6    09 Nov 2015  *                                             Flow  version 2018.04-pre  *
+  Report    6    09 Nov 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -448,7 +448,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at       365  Days *                SPE 3 - CASE 1                                          *
-  Report    7    31 Dec 2015  *                                             Flow  version 2018.04-pre  *
+  Report    7    31 Dec 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -499,7 +499,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at       396  Days *                SPE 3 - CASE 1                                          *
-  Report    8    31 Jan 2016  *                                             Flow  version 2018.04-pre  *
+  Report    8    31 Jan 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -552,7 +552,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at       424  Days *                SPE 3 - CASE 1                                          *
-  Report    9    28 Feb 2016  *                                             Flow  version 2018.04-pre  *
+  Report    9    28 Feb 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -599,11 +599,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step  9/175 at day 424/5475, date = 28-Feb-2016
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.007 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at       455  Days *                SPE 3 - CASE 1                                          *
-  Report   10    30 Mar 2016  *                                             Flow  version 2018.04-pre  *
+  Report   10    30 Mar 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -650,11 +650,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 10/175 at day 455/5475, date = 30-Mar-2016
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.007 sec), linear its =  20 ( 0.003 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at       485  Days *                SPE 3 - CASE 1                                          *
-  Report   11    29 Apr 2016  *                                             Flow  version 2018.04-pre  *
+  Report   11    29 Apr 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -705,7 +705,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at       516  Days *                SPE 3 - CASE 1                                          *
-  Report   12    30 May 2016  *                                             Flow  version 2018.04-pre  *
+  Report   12    30 May 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -752,11 +752,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 12/175 at day 516/5475, date = 30-May-2016
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  20 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at       546  Days *                SPE 3 - CASE 1                                          *
-  Report   13    29 Jun 2016  *                                             Flow  version 2018.04-pre  *
+  Report   13    29 Jun 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -803,11 +803,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 13/175 at day 546/5475, date = 29-Jun-2016
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at       577  Days *                SPE 3 - CASE 1                                          *
-  Report   14    30 Jul 2016  *                                             Flow  version 2018.04-pre  *
+  Report   14    30 Jul 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -858,7 +858,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at       608  Days *                SPE 3 - CASE 1                                          *
-  Report   15    30 Aug 2016  *                                             Flow  version 2018.04-pre  *
+  Report   15    30 Aug 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -909,7 +909,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at       638  Days *                SPE 3 - CASE 1                                          *
-  Report   16    29 Sep 2016  *                                             Flow  version 2018.04-pre  *
+  Report   16    29 Sep 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -960,7 +960,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at       669  Days *                SPE 3 - CASE 1                                          *
-  Report   17    30 Oct 2016  *                                             Flow  version 2018.04-pre  *
+  Report   17    30 Oct 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1007,11 +1007,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 17/175 at day 669/5475, date = 30-Oct-2016
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at       699  Days *                SPE 3 - CASE 1                                          *
-  Report   18    29 Nov 2016  *                                             Flow  version 2018.04-pre  *
+  Report   18    29 Nov 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1062,7 +1062,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at       730  Days *                SPE 3 - CASE 1                                          *
-  Report   19    30 Dec 2016  *                                             Flow  version 2018.04-pre  *
+  Report   19    30 Dec 2016  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1109,11 +1109,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 19/175 at day 730/5475, date = 30-Dec-2016
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  12 ( 0.001 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  12 ( 0.001 sec)
 
                               **************************************************************************
   Balance  at       761  Days *                SPE 3 - CASE 1                                          *
-  Report   20    30 Jan 2017  *                                             Flow  version 2018.04-pre  *
+  Report   20    30 Jan 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1162,11 +1162,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 20/175 at day 761/5475, date = 30-Jan-2017
 
 Time step 0, stepsize 28 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  18 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  18 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at       789  Days *                SPE 3 - CASE 1                                          *
-  Report   21    27 Feb 2017  *                                             Flow  version 2018.04-pre  *
+  Report   21    27 Feb 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1213,11 +1213,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 21/175 at day 789/5475, date = 27-Feb-2017
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  20 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at       820  Days *                SPE 3 - CASE 1                                          *
-  Report   22    30 Mar 2017  *                                             Flow  version 2018.04-pre  *
+  Report   22    30 Mar 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1264,11 +1264,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 22/175 at day 820/5475, date = 30-Mar-2017
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  20 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at       850  Days *                SPE 3 - CASE 1                                          *
-  Report   23    29 Apr 2017  *                                             Flow  version 2018.04-pre  *
+  Report   23    29 Apr 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1315,11 +1315,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 23/175 at day 850/5475, date = 29-Apr-2017
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  20 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at       881  Days *                SPE 3 - CASE 1                                          *
-  Report   24    30 May 2017  *                                             Flow  version 2018.04-pre  *
+  Report   24    30 May 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1366,11 +1366,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 24/175 at day 881/5475, date = 30-May-2017
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  12 ( 0.001 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  12 ( 0.001 sec)
 
                               **************************************************************************
   Balance  at       911  Days *                SPE 3 - CASE 1                                          *
-  Report   25    29 Jun 2017  *                                             Flow  version 2018.04-pre  *
+  Report   25    29 Jun 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1421,7 +1421,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at       942  Days *                SPE 3 - CASE 1                                          *
-  Report   26    30 Jul 2017  *                                             Flow  version 2018.04-pre  *
+  Report   26    30 Jul 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1472,7 +1472,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at       973  Days *                SPE 3 - CASE 1                                          *
-  Report   27    30 Aug 2017  *                                             Flow  version 2018.04-pre  *
+  Report   27    30 Aug 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1523,7 +1523,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1003  Days *                SPE 3 - CASE 1                                          *
-  Report   28    29 Sep 2017  *                                             Flow  version 2018.04-pre  *
+  Report   28    29 Sep 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1574,7 +1574,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1034  Days *                SPE 3 - CASE 1                                          *
-  Report   29    30 Oct 2017  *                                             Flow  version 2018.04-pre  *
+  Report   29    30 Oct 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1625,7 +1625,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1064  Days *                SPE 3 - CASE 1                                          *
-  Report   30    29 Nov 2017  *                                             Flow  version 2018.04-pre  *
+  Report   30    29 Nov 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1672,11 +1672,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 30/175 at day 1064/5475, date = 29-Nov-2017
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  22 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  22 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      1095  Days *                SPE 3 - CASE 1                                          *
-  Report   31    30 Dec 2017  *                                             Flow  version 2018.04-pre  *
+  Report   31    30 Dec 2017  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1727,7 +1727,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1126  Days *                SPE 3 - CASE 1                                          *
-  Report   32    30 Jan 2018  *                                             Flow  version 2018.04-pre  *
+  Report   32    30 Jan 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1780,7 +1780,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1154  Days *                SPE 3 - CASE 1                                          *
-  Report   33    27 Feb 2018  *                                             Flow  version 2018.04-pre  *
+  Report   33    27 Feb 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1831,7 +1831,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1185  Days *                SPE 3 - CASE 1                                          *
-  Report   34    30 Mar 2018  *                                             Flow  version 2018.04-pre  *
+  Report   34    30 Mar 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1878,11 +1878,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 34/175 at day 1185/5475, date = 30-Mar-2018
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      1215  Days *                SPE 3 - CASE 1                                          *
-  Report   35    29 Apr 2018  *                                             Flow  version 2018.04-pre  *
+  Report   35    29 Apr 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1933,7 +1933,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1246  Days *                SPE 3 - CASE 1                                          *
-  Report   36    30 May 2018  *                                             Flow  version 2018.04-pre  *
+  Report   36    30 May 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1984,7 +1984,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1276  Days *                SPE 3 - CASE 1                                          *
-  Report   37    29 Jun 2018  *                                             Flow  version 2018.04-pre  *
+  Report   37    29 Jun 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2035,7 +2035,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1307  Days *                SPE 3 - CASE 1                                          *
-  Report   38    30 Jul 2018  *                                             Flow  version 2018.04-pre  *
+  Report   38    30 Jul 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2086,7 +2086,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1338  Days *                SPE 3 - CASE 1                                          *
-  Report   39    30 Aug 2018  *                                             Flow  version 2018.04-pre  *
+  Report   39    30 Aug 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2137,7 +2137,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1368  Days *                SPE 3 - CASE 1                                          *
-  Report   40    29 Sep 2018  *                                             Flow  version 2018.04-pre  *
+  Report   40    29 Sep 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2188,7 +2188,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1399  Days *                SPE 3 - CASE 1                                          *
-  Report   41    30 Oct 2018  *                                             Flow  version 2018.04-pre  *
+  Report   41    30 Oct 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2239,7 +2239,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1429  Days *                SPE 3 - CASE 1                                          *
-  Report   42    29 Nov 2018  *                                             Flow  version 2018.04-pre  *
+  Report   42    29 Nov 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2290,7 +2290,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1460  Days *                SPE 3 - CASE 1                                          *
-  Report   43    30 Dec 2018  *                                             Flow  version 2018.04-pre  *
+  Report   43    30 Dec 2018  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2341,7 +2341,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1491  Days *                SPE 3 - CASE 1                                          *
-  Report   44    30 Jan 2019  *                                             Flow  version 2018.04-pre  *
+  Report   44    30 Jan 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2394,7 +2394,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1519  Days *                SPE 3 - CASE 1                                          *
-  Report   45    27 Feb 2019  *                                             Flow  version 2018.04-pre  *
+  Report   45    27 Feb 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2441,11 +2441,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 45/175 at day 1519/5475, date = 27-Feb-2019
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  12 ( 0.001 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  12 ( 0.001 sec)
 
                               **************************************************************************
   Balance  at      1550  Days *                SPE 3 - CASE 1                                          *
-  Report   46    30 Mar 2019  *                                             Flow  version 2018.04-pre  *
+  Report   46    30 Mar 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2496,7 +2496,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1580  Days *                SPE 3 - CASE 1                                          *
-  Report   47    29 Apr 2019  *                                             Flow  version 2018.04-pre  *
+  Report   47    29 Apr 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2547,7 +2547,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1611  Days *                SPE 3 - CASE 1                                          *
-  Report   48    30 May 2019  *                                             Flow  version 2018.04-pre  *
+  Report   48    30 May 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2598,7 +2598,7 @@ Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.007 s
 
                               **************************************************************************
   Balance  at      1641  Days *                SPE 3 - CASE 1                                          *
-  Report   49    29 Jun 2019  *                                             Flow  version 2018.04-pre  *
+  Report   49    29 Jun 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2645,11 +2645,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 49/175 at day 1641/5475, date = 29-Jun-2019
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      1672  Days *                SPE 3 - CASE 1                                          *
-  Report   50    30 Jul 2019  *                                             Flow  version 2018.04-pre  *
+  Report   50    30 Jul 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2696,11 +2696,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 50/175 at day 1672/5475, date = 30-Jul-2019
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  13 ( 0.001 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  13 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      1703  Days *                SPE 3 - CASE 1                                          *
-  Report   51    30 Aug 2019  *                                             Flow  version 2018.04-pre  *
+  Report   51    30 Aug 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2751,7 +2751,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1733  Days *                SPE 3 - CASE 1                                          *
-  Report   52    29 Sep 2019  *                                             Flow  version 2018.04-pre  *
+  Report   52    29 Sep 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2798,11 +2798,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 52/175 at day 1733/5475, date = 29-Sep-2019
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      1764  Days *                SPE 3 - CASE 1                                          *
-  Report   53    30 Oct 2019  *                                             Flow  version 2018.04-pre  *
+  Report   53    30 Oct 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2853,7 +2853,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1794  Days *                SPE 3 - CASE 1                                          *
-  Report   54    29 Nov 2019  *                                             Flow  version 2018.04-pre  *
+  Report   54    29 Nov 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2904,7 +2904,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1825  Days *                SPE 3 - CASE 1                                          *
-  Report   55    30 Dec 2019  *                                             Flow  version 2018.04-pre  *
+  Report   55    30 Dec 2019  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -2955,7 +2955,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1856  Days *                SPE 3 - CASE 1                                          *
-  Report   56    30 Jan 2020  *                                             Flow  version 2018.04-pre  *
+  Report   56    30 Jan 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3004,11 +3004,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 56/175 at day 1856/5475, date = 30-Jan-2020
 
 Time step 0, stepsize 28 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  17 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  17 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      1884  Days *                SPE 3 - CASE 1                                          *
-  Report   57    27 Feb 2020  *                                             Flow  version 2018.04-pre  *
+  Report   57    27 Feb 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3059,7 +3059,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1915  Days *                SPE 3 - CASE 1                                          *
-  Report   58    29 Mar 2020  *                                             Flow  version 2018.04-pre  *
+  Report   58    29 Mar 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3110,7 +3110,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1945  Days *                SPE 3 - CASE 1                                          *
-  Report   59    28 Apr 2020  *                                             Flow  version 2018.04-pre  *
+  Report   59    28 Apr 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3161,7 +3161,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      1976  Days *                SPE 3 - CASE 1                                          *
-  Report   60    29 May 2020  *                                             Flow  version 2018.04-pre  *
+  Report   60    29 May 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3212,7 +3212,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2006  Days *                SPE 3 - CASE 1                                          *
-  Report   61    28 Jun 2020  *                                             Flow  version 2018.04-pre  *
+  Report   61    28 Jun 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3263,7 +3263,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2037  Days *                SPE 3 - CASE 1                                          *
-  Report   62    29 Jul 2020  *                                             Flow  version 2018.04-pre  *
+  Report   62    29 Jul 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3314,7 +3314,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2068  Days *                SPE 3 - CASE 1                                          *
-  Report   63    29 Aug 2020  *                                             Flow  version 2018.04-pre  *
+  Report   63    29 Aug 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3365,7 +3365,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2098  Days *                SPE 3 - CASE 1                                          *
-  Report   64    28 Sep 2020  *                                             Flow  version 2018.04-pre  *
+  Report   64    28 Sep 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3416,7 +3416,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2129  Days *                SPE 3 - CASE 1                                          *
-  Report   65    29 Oct 2020  *                                             Flow  version 2018.04-pre  *
+  Report   65    29 Oct 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3463,11 +3463,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 65/175 at day 2129/5475, date = 29-Oct-2020
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      2159  Days *                SPE 3 - CASE 1                                          *
-  Report   66    28 Nov 2020  *                                             Flow  version 2018.04-pre  *
+  Report   66    28 Nov 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3514,11 +3514,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 66/175 at day 2159/5475, date = 28-Nov-2020
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      2190  Days *                SPE 3 - CASE 1                                          *
-  Report   67    29 Dec 2020  *                                             Flow  version 2018.04-pre  *
+  Report   67    29 Dec 2020  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3569,7 +3569,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2221  Days *                SPE 3 - CASE 1                                          *
-  Report   68    29 Jan 2021  *                                             Flow  version 2018.04-pre  *
+  Report   68    29 Jan 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3622,7 +3622,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 s
 
                               **************************************************************************
   Balance  at      2249  Days *                SPE 3 - CASE 1                                          *
-  Report   69    26 Feb 2021  *                                             Flow  version 2018.04-pre  *
+  Report   69    26 Feb 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3669,11 +3669,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 69/175 at day 2249/5475, date = 26-Feb-2021
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  20 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      2280  Days *                SPE 3 - CASE 1                                          *
-  Report   70    29 Mar 2021  *                                             Flow  version 2018.04-pre  *
+  Report   70    29 Mar 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3724,7 +3724,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2310  Days *                SPE 3 - CASE 1                                          *
-  Report   71    28 Apr 2021  *                                             Flow  version 2018.04-pre  *
+  Report   71    28 Apr 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3771,11 +3771,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 71/175 at day 2310/5475, date = 28-Apr-2021
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  18 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  18 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      2341  Days *                SPE 3 - CASE 1                                          *
-  Report   72    29 May 2021  *                                             Flow  version 2018.04-pre  *
+  Report   72    29 May 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3826,7 +3826,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2371  Days *                SPE 3 - CASE 1                                          *
-  Report   73    28 Jun 2021  *                                             Flow  version 2018.04-pre  *
+  Report   73    28 Jun 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3877,7 +3877,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2402  Days *                SPE 3 - CASE 1                                          *
-  Report   74    29 Jul 2021  *                                             Flow  version 2018.04-pre  *
+  Report   74    29 Jul 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3924,11 +3924,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 74/175 at day 2402/5475, date = 29-Jul-2021
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      2433  Days *                SPE 3 - CASE 1                                          *
-  Report   75    29 Aug 2021  *                                             Flow  version 2018.04-pre  *
+  Report   75    29 Aug 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -3979,7 +3979,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2463  Days *                SPE 3 - CASE 1                                          *
-  Report   76    28 Sep 2021  *                                             Flow  version 2018.04-pre  *
+  Report   76    28 Sep 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4030,7 +4030,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2494  Days *                SPE 3 - CASE 1                                          *
-  Report   77    29 Oct 2021  *                                             Flow  version 2018.04-pre  *
+  Report   77    29 Oct 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4077,11 +4077,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 77/175 at day 2494/5475, date = 29-Oct-2021
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      2524  Days *                SPE 3 - CASE 1                                          *
-  Report   78    28 Nov 2021  *                                             Flow  version 2018.04-pre  *
+  Report   78    28 Nov 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4132,7 +4132,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2555  Days *                SPE 3 - CASE 1                                          *
-  Report   79    29 Dec 2021  *                                             Flow  version 2018.04-pre  *
+  Report   79    29 Dec 2021  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4183,7 +4183,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2586  Days *                SPE 3 - CASE 1                                          *
-  Report   80    29 Jan 2022  *                                             Flow  version 2018.04-pre  *
+  Report   80    29 Jan 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4232,11 +4232,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 80/175 at day 2586/5475, date = 29-Jan-2022
 
 Time step 0, stepsize 28 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.010 sec), linear its =  18 ( 0.003 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  18 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      2614  Days *                SPE 3 - CASE 1                                          *
-  Report   81    26 Feb 2022  *                                             Flow  version 2018.04-pre  *
+  Report   81    26 Feb 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4283,11 +4283,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 81/175 at day 2614/5475, date = 26-Feb-2022
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.010 sec), linear its =  21 ( 0.003 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  21 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      2645  Days *                SPE 3 - CASE 1                                          *
-  Report   82    29 Mar 2022  *                                             Flow  version 2018.04-pre  *
+  Report   82    29 Mar 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4334,11 +4334,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 82/175 at day 2645/5475, date = 29-Mar-2022
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.008 sec), linear its =  20 ( 0.003 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      2675  Days *                SPE 3 - CASE 1                                          *
-  Report   83    28 Apr 2022  *                                             Flow  version 2018.04-pre  *
+  Report   83    28 Apr 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4389,7 +4389,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2706  Days *                SPE 3 - CASE 1                                          *
-  Report   84    29 May 2022  *                                             Flow  version 2018.04-pre  *
+  Report   84    29 May 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4440,7 +4440,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2736  Days *                SPE 3 - CASE 1                                          *
-  Report   85    28 Jun 2022  *                                             Flow  version 2018.04-pre  *
+  Report   85    28 Jun 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4491,7 +4491,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2767  Days *                SPE 3 - CASE 1                                          *
-  Report   86    29 Jul 2022  *                                             Flow  version 2018.04-pre  *
+  Report   86    29 Jul 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4542,7 +4542,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2798  Days *                SPE 3 - CASE 1                                          *
-  Report   87    29 Aug 2022  *                                             Flow  version 2018.04-pre  *
+  Report   87    29 Aug 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4593,7 +4593,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2828  Days *                SPE 3 - CASE 1                                          *
-  Report   88    28 Sep 2022  *                                             Flow  version 2018.04-pre  *
+  Report   88    28 Sep 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4644,7 +4644,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2859  Days *                SPE 3 - CASE 1                                          *
-  Report   89    29 Oct 2022  *                                             Flow  version 2018.04-pre  *
+  Report   89    29 Oct 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4695,7 +4695,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2889  Days *                SPE 3 - CASE 1                                          *
-  Report   90    28 Nov 2022  *                                             Flow  version 2018.04-pre  *
+  Report   90    28 Nov 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4746,7 +4746,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2920  Days *                SPE 3 - CASE 1                                          *
-  Report   91    29 Dec 2022  *                                             Flow  version 2018.04-pre  *
+  Report   91    29 Dec 2022  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4793,11 +4793,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 91/175 at day 2920/5475, date = 29-Dec-2022
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      2951  Days *                SPE 3 - CASE 1                                          *
-  Report   92    29 Jan 2023  *                                             Flow  version 2018.04-pre  *
+  Report   92    29 Jan 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4850,7 +4850,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      2979  Days *                SPE 3 - CASE 1                                          *
-  Report   93    26 Feb 2023  *                                             Flow  version 2018.04-pre  *
+  Report   93    26 Feb 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4901,7 +4901,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3010  Days *                SPE 3 - CASE 1                                          *
-  Report   94    29 Mar 2023  *                                             Flow  version 2018.04-pre  *
+  Report   94    29 Mar 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -4952,7 +4952,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3040  Days *                SPE 3 - CASE 1                                          *
-  Report   95    28 Apr 2023  *                                             Flow  version 2018.04-pre  *
+  Report   95    28 Apr 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5003,7 +5003,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3071  Days *                SPE 3 - CASE 1                                          *
-  Report   96    29 May 2023  *                                             Flow  version 2018.04-pre  *
+  Report   96    29 May 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5054,7 +5054,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3101  Days *                SPE 3 - CASE 1                                          *
-  Report   97    28 Jun 2023  *                                             Flow  version 2018.04-pre  *
+  Report   97    28 Jun 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5105,7 +5105,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3132  Days *                SPE 3 - CASE 1                                          *
-  Report   98    29 Jul 2023  *                                             Flow  version 2018.04-pre  *
+  Report   98    29 Jul 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5156,7 +5156,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3163  Days *                SPE 3 - CASE 1                                          *
-  Report   99    29 Aug 2023  *                                             Flow  version 2018.04-pre  *
+  Report   99    29 Aug 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5207,7 +5207,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3193  Days *                SPE 3 - CASE 1                                          *
-  Report  100    28 Sep 2023  *                                             Flow  version 2018.04-pre  *
+  Report  100    28 Sep 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5258,7 +5258,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3224  Days *                SPE 3 - CASE 1                                          *
-  Report  101    29 Oct 2023  *                                             Flow  version 2018.04-pre  *
+  Report  101    29 Oct 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5309,7 +5309,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3254  Days *                SPE 3 - CASE 1                                          *
-  Report  102    28 Nov 2023  *                                             Flow  version 2018.04-pre  *
+  Report  102    28 Nov 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5360,7 +5360,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3285  Days *                SPE 3 - CASE 1                                          *
-  Report  103    29 Dec 2023  *                                             Flow  version 2018.04-pre  *
+  Report  103    29 Dec 2023  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5411,7 +5411,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3316  Days *                SPE 3 - CASE 1                                          *
-  Report  104    29 Jan 2024  *                                             Flow  version 2018.04-pre  *
+  Report  104    29 Jan 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5464,7 +5464,7 @@ Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.007 s
 
                               **************************************************************************
   Balance  at      3344  Days *                SPE 3 - CASE 1                                          *
-  Report  105    26 Feb 2024  *                                             Flow  version 2018.04-pre  *
+  Report  105    26 Feb 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5515,7 +5515,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3375  Days *                SPE 3 - CASE 1                                          *
-  Report  106    28 Mar 2024  *                                             Flow  version 2018.04-pre  *
+  Report  106    28 Mar 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5566,7 +5566,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3405  Days *                SPE 3 - CASE 1                                          *
-  Report  107    27 Apr 2024  *                                             Flow  version 2018.04-pre  *
+  Report  107    27 Apr 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5617,7 +5617,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3436  Days *                SPE 3 - CASE 1                                          *
-  Report  108    28 May 2024  *                                             Flow  version 2018.04-pre  *
+  Report  108    28 May 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5664,11 +5664,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 108/175 at day 3436/5475, date = 28-May-2024
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  18 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  18 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      3466  Days *                SPE 3 - CASE 1                                          *
-  Report  109    27 Jun 2024  *                                             Flow  version 2018.04-pre  *
+  Report  109    27 Jun 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5715,11 +5715,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 109/175 at day 3466/5475, date = 27-Jun-2024
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      3497  Days *                SPE 3 - CASE 1                                          *
-  Report  110    28 Jul 2024  *                                             Flow  version 2018.04-pre  *
+  Report  110    28 Jul 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5770,7 +5770,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3528  Days *                SPE 3 - CASE 1                                          *
-  Report  111    28 Aug 2024  *                                             Flow  version 2018.04-pre  *
+  Report  111    28 Aug 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5821,7 +5821,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3558  Days *                SPE 3 - CASE 1                                          *
-  Report  112    27 Sep 2024  *                                             Flow  version 2018.04-pre  *
+  Report  112    27 Sep 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5872,7 +5872,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3589  Days *                SPE 3 - CASE 1                                          *
-  Report  113    28 Oct 2024  *                                             Flow  version 2018.04-pre  *
+  Report  113    28 Oct 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5923,7 +5923,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3619  Days *                SPE 3 - CASE 1                                          *
-  Report  114    27 Nov 2024  *                                             Flow  version 2018.04-pre  *
+  Report  114    27 Nov 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -5974,7 +5974,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3650  Days *                SPE 3 - CASE 1                                          *
-  Report  115    28 Dec 2024  *                                             Flow  version 2018.04-pre  *
+  Report  115    28 Dec 2024  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6021,11 +6021,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 115/175 at day 3650/5475, date = 28-Dec-2024
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      3681  Days *                SPE 3 - CASE 1                                          *
-  Report  116    28 Jan 2025  *                                             Flow  version 2018.04-pre  *
+  Report  116    28 Jan 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6078,7 +6078,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 s
 
                               **************************************************************************
   Balance  at      3709  Days *                SPE 3 - CASE 1                                          *
-  Report  117    25 Feb 2025  *                                             Flow  version 2018.04-pre  *
+  Report  117    25 Feb 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6129,7 +6129,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3740  Days *                SPE 3 - CASE 1                                          *
-  Report  118    28 Mar 2025  *                                             Flow  version 2018.04-pre  *
+  Report  118    28 Mar 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6180,7 +6180,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3770  Days *                SPE 3 - CASE 1                                          *
-  Report  119    27 Apr 2025  *                                             Flow  version 2018.04-pre  *
+  Report  119    27 Apr 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6231,7 +6231,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3801  Days *                SPE 3 - CASE 1                                          *
-  Report  120    28 May 2025  *                                             Flow  version 2018.04-pre  *
+  Report  120    28 May 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6282,7 +6282,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3831  Days *                SPE 3 - CASE 1                                          *
-  Report  121    27 Jun 2025  *                                             Flow  version 2018.04-pre  *
+  Report  121    27 Jun 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6333,7 +6333,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3862  Days *                SPE 3 - CASE 1                                          *
-  Report  122    28 Jul 2025  *                                             Flow  version 2018.04-pre  *
+  Report  122    28 Jul 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6384,7 +6384,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      3893  Days *                SPE 3 - CASE 1                                          *
-  Report  123    28 Aug 2025  *                                             Flow  version 2018.04-pre  *
+  Report  123    28 Aug 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6435,7 +6435,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 s
 
                               **************************************************************************
   Balance  at      3923  Days *                SPE 3 - CASE 1                                          *
-  Report  124    27 Sep 2025  *                                             Flow  version 2018.04-pre  *
+  Report  124    27 Sep 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6482,11 +6482,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 124/175 at day 3923/5475, date = 27-Sep-2025
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  18 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  18 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      3954  Days *                SPE 3 - CASE 1                                          *
-  Report  125    28 Oct 2025  *                                             Flow  version 2018.04-pre  *
+  Report  125    28 Oct 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6533,11 +6533,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 125/175 at day 3954/5475, date = 28-Oct-2025
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  18 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  18 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      3984  Days *                SPE 3 - CASE 1                                          *
-  Report  126    27 Nov 2025  *                                             Flow  version 2018.04-pre  *
+  Report  126    27 Nov 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6584,11 +6584,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 126/175 at day 3984/5475, date = 27-Nov-2025
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  18 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  18 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      4015  Days *                SPE 3 - CASE 1                                          *
-  Report  127    28 Dec 2025  *                                             Flow  version 2018.04-pre  *
+  Report  127    28 Dec 2025  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6639,7 +6639,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4046  Days *                SPE 3 - CASE 1                                          *
-  Report  128    28 Jan 2026  *                                             Flow  version 2018.04-pre  *
+  Report  128    28 Jan 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6688,11 +6688,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 128/175 at day 4046/5475, date = 28-Jan-2026
 
 Time step 0, stepsize 28 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  16 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  16 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      4074  Days *                SPE 3 - CASE 1                                          *
-  Report  129    25 Feb 2026  *                                             Flow  version 2018.04-pre  *
+  Report  129    25 Feb 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6739,11 +6739,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 129/175 at day 4074/5475, date = 25-Feb-2026
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      4105  Days *                SPE 3 - CASE 1                                          *
-  Report  130    28 Mar 2026  *                                             Flow  version 2018.04-pre  *
+  Report  130    28 Mar 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6790,11 +6790,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 130/175 at day 4105/5475, date = 28-Mar-2026
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  16 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  16 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      4135  Days *                SPE 3 - CASE 1                                          *
-  Report  131    27 Apr 2026  *                                             Flow  version 2018.04-pre  *
+  Report  131    27 Apr 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6845,7 +6845,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4166  Days *                SPE 3 - CASE 1                                          *
-  Report  132    28 May 2026  *                                             Flow  version 2018.04-pre  *
+  Report  132    28 May 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6896,7 +6896,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4196  Days *                SPE 3 - CASE 1                                          *
-  Report  133    27 Jun 2026  *                                             Flow  version 2018.04-pre  *
+  Report  133    27 Jun 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6947,7 +6947,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4227  Days *                SPE 3 - CASE 1                                          *
-  Report  134    28 Jul 2026  *                                             Flow  version 2018.04-pre  *
+  Report  134    28 Jul 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -6998,7 +6998,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4258  Days *                SPE 3 - CASE 1                                          *
-  Report  135    28 Aug 2026  *                                             Flow  version 2018.04-pre  *
+  Report  135    28 Aug 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7049,7 +7049,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4288  Days *                SPE 3 - CASE 1                                          *
-  Report  136    27 Sep 2026  *                                             Flow  version 2018.04-pre  *
+  Report  136    27 Sep 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7096,11 +7096,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 136/175 at day 4288/5475, date = 27-Sep-2026
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      4319  Days *                SPE 3 - CASE 1                                          *
-  Report  137    28 Oct 2026  *                                             Flow  version 2018.04-pre  *
+  Report  137    28 Oct 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7147,11 +7147,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 137/175 at day 4319/5475, date = 28-Oct-2026
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      4349  Days *                SPE 3 - CASE 1                                          *
-  Report  138    27 Nov 2026  *                                             Flow  version 2018.04-pre  *
+  Report  138    27 Nov 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7202,7 +7202,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 s
 
                               **************************************************************************
   Balance  at      4380  Days *                SPE 3 - CASE 1                                          *
-  Report  139    28 Dec 2026  *                                             Flow  version 2018.04-pre  *
+  Report  139    28 Dec 2026  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7253,7 +7253,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4411  Days *                SPE 3 - CASE 1                                          *
-  Report  140    28 Jan 2027  *                                             Flow  version 2018.04-pre  *
+  Report  140    28 Jan 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7302,11 +7302,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 140/175 at day 4411/5475, date = 28-Jan-2027
 
 Time step 0, stepsize 28 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  18 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  18 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      4439  Days *                SPE 3 - CASE 1                                          *
-  Report  141    25 Feb 2027  *                                             Flow  version 2018.04-pre  *
+  Report  141    25 Feb 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7357,7 +7357,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4470  Days *                SPE 3 - CASE 1                                          *
-  Report  142    28 Mar 2027  *                                             Flow  version 2018.04-pre  *
+  Report  142    28 Mar 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7408,7 +7408,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4500  Days *                SPE 3 - CASE 1                                          *
-  Report  143    27 Apr 2027  *                                             Flow  version 2018.04-pre  *
+  Report  143    27 Apr 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7459,7 +7459,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4531  Days *                SPE 3 - CASE 1                                          *
-  Report  144    28 May 2027  *                                             Flow  version 2018.04-pre  *
+  Report  144    28 May 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7510,7 +7510,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4561  Days *                SPE 3 - CASE 1                                          *
-  Report  145    27 Jun 2027  *                                             Flow  version 2018.04-pre  *
+  Report  145    27 Jun 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7557,11 +7557,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 145/175 at day 4561/5475, date = 27-Jun-2027
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  18 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  18 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      4592  Days *                SPE 3 - CASE 1                                          *
-  Report  146    28 Jul 2027  *                                             Flow  version 2018.04-pre  *
+  Report  146    28 Jul 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7612,7 +7612,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4623  Days *                SPE 3 - CASE 1                                          *
-  Report  147    28 Aug 2027  *                                             Flow  version 2018.04-pre  *
+  Report  147    28 Aug 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7663,7 +7663,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4653  Days *                SPE 3 - CASE 1                                          *
-  Report  148    27 Sep 2027  *                                             Flow  version 2018.04-pre  *
+  Report  148    27 Sep 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7714,7 +7714,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4684  Days *                SPE 3 - CASE 1                                          *
-  Report  149    28 Oct 2027  *                                             Flow  version 2018.04-pre  *
+  Report  149    28 Oct 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7761,11 +7761,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 149/175 at day 4684/5475, date = 28-Oct-2027
 
 Time step 0, stepsize 30 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  21 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  21 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      4714  Days *                SPE 3 - CASE 1                                          *
-  Report  150    27 Nov 2027  *                                             Flow  version 2018.04-pre  *
+  Report  150    27 Nov 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7816,7 +7816,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4745  Days *                SPE 3 - CASE 1                                          *
-  Report  151    28 Dec 2027  *                                             Flow  version 2018.04-pre  *
+  Report  151    28 Dec 2027  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7867,7 +7867,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4776  Days *                SPE 3 - CASE 1                                          *
-  Report  152    28 Jan 2028  *                                             Flow  version 2018.04-pre  *
+  Report  152    28 Jan 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7920,7 +7920,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4804  Days *                SPE 3 - CASE 1                                          *
-  Report  153    25 Feb 2028  *                                             Flow  version 2018.04-pre  *
+  Report  153    25 Feb 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -7967,11 +7967,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 153/175 at day 4804/5475, date = 25-Feb-2028
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      4835  Days *                SPE 3 - CASE 1                                          *
-  Report  154    27 Mar 2028  *                                             Flow  version 2018.04-pre  *
+  Report  154    27 Mar 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8022,7 +8022,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4865  Days *                SPE 3 - CASE 1                                          *
-  Report  155    26 Apr 2028  *                                             Flow  version 2018.04-pre  *
+  Report  155    26 Apr 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8073,7 +8073,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4896  Days *                SPE 3 - CASE 1                                          *
-  Report  156    27 May 2028  *                                             Flow  version 2018.04-pre  *
+  Report  156    27 May 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8124,7 +8124,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4926  Days *                SPE 3 - CASE 1                                          *
-  Report  157    26 Jun 2028  *                                             Flow  version 2018.04-pre  *
+  Report  157    26 Jun 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8175,7 +8175,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      4957  Days *                SPE 3 - CASE 1                                          *
-  Report  158    27 Jul 2028  *                                             Flow  version 2018.04-pre  *
+  Report  158    27 Jul 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8222,11 +8222,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 158/175 at day 4957/5475, date = 27-Jul-2028
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  20 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  20 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      4988  Days *                SPE 3 - CASE 1                                          *
-  Report  159    27 Aug 2028  *                                             Flow  version 2018.04-pre  *
+  Report  159    27 Aug 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8277,7 +8277,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5018  Days *                SPE 3 - CASE 1                                          *
-  Report  160    26 Sep 2028  *                                             Flow  version 2018.04-pre  *
+  Report  160    26 Sep 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8328,7 +8328,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5049  Days *                SPE 3 - CASE 1                                          *
-  Report  161    27 Oct 2028  *                                             Flow  version 2018.04-pre  *
+  Report  161    27 Oct 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8379,7 +8379,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5079  Days *                SPE 3 - CASE 1                                          *
-  Report  162    26 Nov 2028  *                                             Flow  version 2018.04-pre  *
+  Report  162    26 Nov 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8430,7 +8430,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5110  Days *                SPE 3 - CASE 1                                          *
-  Report  163    27 Dec 2028  *                                             Flow  version 2018.04-pre  *
+  Report  163    27 Dec 2028  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8481,7 +8481,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5141  Days *                SPE 3 - CASE 1                                          *
-  Report  164    27 Jan 2029  *                                             Flow  version 2018.04-pre  *
+  Report  164    27 Jan 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8534,7 +8534,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5169  Days *                SPE 3 - CASE 1                                          *
-  Report  165    24 Feb 2029  *                                             Flow  version 2018.04-pre  *
+  Report  165    24 Feb 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8585,7 +8585,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5200  Days *                SPE 3 - CASE 1                                          *
-  Report  166    27 Mar 2029  *                                             Flow  version 2018.04-pre  *
+  Report  166    27 Mar 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8636,7 +8636,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5230  Days *                SPE 3 - CASE 1                                          *
-  Report  167    26 Apr 2029  *                                             Flow  version 2018.04-pre  *
+  Report  167    26 Apr 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8687,7 +8687,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5261  Days *                SPE 3 - CASE 1                                          *
-  Report  168    27 May 2029  *                                             Flow  version 2018.04-pre  *
+  Report  168    27 May 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8738,7 +8738,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5291  Days *                SPE 3 - CASE 1                                          *
-  Report  169    26 Jun 2029  *                                             Flow  version 2018.04-pre  *
+  Report  169    26 Jun 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8785,11 +8785,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 169/175 at day 5291/5475, date = 26-Jun-2029
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  17 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  17 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      5322  Days *                SPE 3 - CASE 1                                          *
-  Report  170    27 Jul 2029  *                                             Flow  version 2018.04-pre  *
+  Report  170    27 Jul 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8840,7 +8840,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5353  Days *                SPE 3 - CASE 1                                          *
-  Report  171    27 Aug 2029  *                                             Flow  version 2018.04-pre  *
+  Report  171    27 Aug 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8891,7 +8891,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5383  Days *                SPE 3 - CASE 1                                          *
-  Report  172    26 Sep 2029  *                                             Flow  version 2018.04-pre  *
+  Report  172    26 Sep 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8938,11 +8938,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 172/175 at day 5383/5475, date = 26-Sep-2029
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  18 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  18 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      5414  Days *                SPE 3 - CASE 1                                          *
-  Report  173    27 Oct 2029  *                                             Flow  version 2018.04-pre  *
+  Report  173    27 Oct 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -8993,7 +8993,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 s
 
                               **************************************************************************
   Balance  at      5444  Days *                SPE 3 - CASE 1                                          *
-  Report  174    26 Nov 2029  *                                             Flow  version 2018.04-pre  *
+  Report  174    26 Nov 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -9040,11 +9040,11 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 Report step 174/175 at day 5444/5475, date = 26-Nov-2029
 
 Time step 0, stepsize 31 days.
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.006 sec), linear its =  19 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.005 sec), linear its =  19 ( 0.002 sec)
 
                               **************************************************************************
   Balance  at      5475  Days *                SPE 3 - CASE 1                                          *
-  Report  175    27 Dec 2029  *                                             Flow  version 2018.04-pre  *
+  Report  175    27 Dec 2029  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -9091,12 +9091,12 @@ Warning: Keyword 'BRS' is unhandled for output to file.
 
 ================    End of simulation     ===============
 
-Total time (seconds):         1.60191
-Solver time (seconds):        1.51853
- Assembly time (seconds):     1.01779 (Failed: 0; 0%)
- Linear solve time (seconds): 0.343386 (Failed: 0; 0%)
- Update time (seconds):       0.069219 (Failed: 0; 0%)
- Output write time (seconds): 0.0721839
+Total time (seconds):         1.53031
+Solver time (seconds):        1.45358
+ Assembly time (seconds):     0.96993 (Failed: 0; 0%)
+ Linear solve time (seconds): 0.331701 (Failed: 0; 0%)
+ Update time (seconds):       0.0661338 (Failed: 0; 0%)
+ Output write time (seconds): 0.0660787
 Overall Well Iterations:      179 (Failed: 0; 0%)
 Overall Linearizations:       544 (Failed: 0; 0%)
 Overall Newton Iterations:    365 (Failed: 0; 0%)

--- a/spe3/opm-simulation-reference/flow_legacy/SPE3CASE1.PRT
+++ b/spe3/opm-simulation-reference/flow_legacy/SPE3CASE1.PRT
@@ -24,7 +24,7 @@ Time step    0 at day 0/5475, date = 01-Jan-2015
 
 Time step 0, stepsize 1 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =   9 ( 0.003 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =   9 ( 0.004 sec)
 
 Time step 1, stepsize 3 days.
 well converged iter: 1
@@ -32,7 +32,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 
 Time step 2, stepsize 9 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  15 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  15 ( 0.004 sec)
 
 Time step 3, stepsize 19.5714 days.
 well converged iter: 1
@@ -67,7 +67,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.100628 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.100808 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -83,7 +83,7 @@ Time step    1 at day 52.1428/5475, date = 22-Feb-2015
 
 Time step 0, stepsize 52.1428 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  21 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  21 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3468.75  PSIA                 :
@@ -110,7 +110,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.121635 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.122362 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -126,7 +126,7 @@ Time step    2 at day 104.286/5475, date = 15-Apr-2015
 
 Time step 0, stepsize 52.1428 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.020 sec), linear its =  30 ( 0.007 sec)
+Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.020 sec), linear its =  30 ( 0.006 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3437.84  PSIA                 :
@@ -153,7 +153,7 @@ Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.020 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.150055 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.150418 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -169,7 +169,7 @@ Time step    3 at day 156.429/5475, date = 06-Jun-2015
 
 Time step 0, stepsize 52.1428 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  4, linearizations =  5 ( 0.024 sec), linear its =  38 ( 0.008 sec)
+Time step summary: well its =  1, newton its =  4, linearizations =  5 ( 0.027 sec), linear its =  38 ( 0.009 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3416.67  PSIA                 :
@@ -196,7 +196,7 @@ Time step summary: well its =  1, newton its =  4, linearizations =  5 ( 0.024 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.184553 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.188332 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -212,7 +212,7 @@ Time step    4 at day 208.571/5475, date = 28-Jul-2015
 
 Time step 0, stepsize 52.1428 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.019 sec), linear its =  31 ( 0.006 sec)
+Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.020 sec), linear its =  31 ( 0.006 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3399.74  PSIA                 :
@@ -239,7 +239,7 @@ Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.019 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.211978 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.215648 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -282,7 +282,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.231680 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.235208 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -298,7 +298,7 @@ Time step    6 at day 312.857/5475, date = 09-Nov-2015
 
 Time step 0, stepsize 52.1428 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3365.26  PSIA                 :
@@ -325,7 +325,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.251902 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.256076 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -368,7 +368,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.271962 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.275955 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -411,7 +411,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.291941 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.295863 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -427,7 +427,7 @@ Time step    9 at day 424/5475, date = 28-Feb-2016
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3334.44  PSIA                 :
@@ -454,7 +454,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.314297 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.315821 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -497,7 +497,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.334865 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.335707 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -513,7 +513,7 @@ Time step   11 at day 485/5475, date = 29-Apr-2016
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  12 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  12 ( 0.003 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3313.06  PSIA                 :
@@ -540,7 +540,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.354643 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.355286 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -583,7 +583,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.374488 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.375195 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -626,7 +626,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.394511 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.395188 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -642,7 +642,7 @@ Time step   14 at day 577/5475, date = 30-Jul-2016
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  15 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  15 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3280.16  PSIA                 :
@@ -669,7 +669,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.414551 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.415626 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -712,7 +712,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.434559 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.435355 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -728,7 +728,7 @@ Time step   16 at day 638/5475, date = 29-Sep-2016
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  16 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  16 ( 0.005 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3257.94  PSIA                 :
@@ -755,7 +755,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.454536 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.457159 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -798,7 +798,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.475057 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.477510 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -814,7 +814,7 @@ Time step   18 at day 699/5475, date = 29-Nov-2016
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.003 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3235.48  PSIA                 :
@@ -841,7 +841,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.494942 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.497236 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -857,7 +857,7 @@ Time step   19 at day 730/5475, date = 30-Dec-2016
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  11 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3224.02  PSIA                 :
@@ -884,7 +884,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.514843 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.518348 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -927,7 +927,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.535663 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.538922 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -970,7 +970,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.556182 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.559526 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1013,7 +1013,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.576240 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.579005 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1029,7 +1029,7 @@ Time step   23 at day 850/5475, date = 29-Apr-2017
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        3179.2  PSIA                 :
@@ -1056,7 +1056,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.596621 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.600552 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1072,7 +1072,7 @@ Time step   24 at day 881/5475, date = 30-May-2017
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.003 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3167.92  PSIA                 :
@@ -1099,7 +1099,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.616634 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.620285 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1142,7 +1142,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.637378 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.640763 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1185,7 +1185,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.658754 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.661704 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1201,7 +1201,7 @@ Time step   27 at day 973/5475, date = 30-Aug-2017
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  20 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  20 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3133.14  PSIA                 :
@@ -1228,7 +1228,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.681039 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.683348 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1244,7 +1244,7 @@ Time step   28 at day 1003/5475, date = 29-Sep-2017
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  12 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  12 ( 0.003 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3121.42  PSIA                 :
@@ -1271,7 +1271,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.701734 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.703127 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1287,7 +1287,7 @@ Time step   29 at day 1034/5475, date = 30-Oct-2017
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3110.04  PSIA                 :
@@ -1314,7 +1314,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.722868 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.723450 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1330,7 +1330,7 @@ Time step   30 at day 1064/5475, date = 29-Nov-2017
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        3098.3  PSIA                 :
@@ -1357,7 +1357,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.744148 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.743732 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1373,7 +1373,7 @@ Time step   31 at day 1095/5475, date = 30-Dec-2017
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  16 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  16 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3086.54  PSIA                 :
@@ -1400,7 +1400,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.766345 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.763803 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1416,7 +1416,7 @@ Time step   32 at day 1126/5475, date = 30-Jan-2018
 
 Time step 0, stepsize 28 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.018 sec), linear its =  10 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  10 ( 0.003 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3075.91  PSIA                 :
@@ -1443,7 +1443,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.018 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.789479 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.782822 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1459,7 +1459,7 @@ Time step   33 at day 1154/5475, date = 27-Feb-2018
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3064.12  PSIA                 :
@@ -1486,7 +1486,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.810558 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.802772 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1502,7 +1502,7 @@ Time step   34 at day 1185/5475, date = 30-Mar-2018
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3052.73  PSIA                 :
@@ -1529,7 +1529,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.832523 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.822636 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1545,7 +1545,7 @@ Time step   35 at day 1215/5475, date = 29-Apr-2018
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3040.98  PSIA                 :
@@ -1572,7 +1572,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.853623 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.842782 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1588,7 +1588,7 @@ Time step   36 at day 1246/5475, date = 30-May-2018
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3029.62  PSIA                 :
@@ -1615,7 +1615,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.875604 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.862420 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1631,7 +1631,7 @@ Time step   37 at day 1276/5475, date = 29-Jun-2018
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3017.89  PSIA                 :
@@ -1658,7 +1658,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.897291 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.882451 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1674,7 +1674,7 @@ Time step   38 at day 1307/5475, date = 30-Jul-2018
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        3006.4  PSIA                 :
@@ -1701,7 +1701,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.918927 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.902732 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1717,7 +1717,7 @@ Time step   39 at day 1338/5475, date = 30-Aug-2018
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2996.32  PSIA                 :
@@ -1744,7 +1744,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.940353 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.922975 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1760,7 +1760,7 @@ Time step   40 at day 1368/5475, date = 29-Sep-2018
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2986.93  PSIA                 :
@@ -1787,7 +1787,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.962798 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.943382 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1803,7 +1803,7 @@ Time step   41 at day 1399/5475, date = 30-Oct-2018
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2978.21  PSIA                 :
@@ -1830,7 +1830,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.984132 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.963711 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1846,7 +1846,7 @@ Time step   42 at day 1429/5475, date = 29-Nov-2018
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  11 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.003 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2969.25  PSIA                 :
@@ -1873,7 +1873,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.004538 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 0.983556 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1889,7 +1889,7 @@ Time step   43 at day 1460/5475, date = 30-Dec-2018
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  17 ( 0.005 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2960.33  PSIA                 :
@@ -1916,7 +1916,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.025421 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.006528 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1932,7 +1932,7 @@ Time step   44 at day 1491/5475, date = 30-Jan-2019
 
 Time step 0, stepsize 28 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  11 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2952.32  PSIA                 :
@@ -1959,7 +1959,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.045664 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.027256 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -1975,7 +1975,7 @@ Time step   45 at day 1519/5475, date = 27-Feb-2019
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  10 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  10 ( 0.003 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2943.47  PSIA                 :
@@ -2002,7 +2002,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.066572 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.047059 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2045,7 +2045,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.087066 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.068022 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2088,7 +2088,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.107111 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.088288 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2131,7 +2131,7 @@ Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.020 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.134303 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.115295 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2147,7 +2147,7 @@ Time step   49 at day 1641/5475, date = 29-Jun-2019
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2909.12  PSIA                 :
@@ -2174,7 +2174,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.155843 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.135217 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2217,7 +2217,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.176074 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.156758 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2233,7 +2233,7 @@ Time step   51 at day 1703/5475, date = 30-Aug-2019
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.003 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2892.28  PSIA                 :
@@ -2260,7 +2260,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.196167 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.176447 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2276,7 +2276,7 @@ Time step   52 at day 1733/5475, date = 29-Sep-2019
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2883.77  PSIA                 :
@@ -2303,7 +2303,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.217093 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.196481 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2319,7 +2319,7 @@ Time step   53 at day 1764/5475, date = 30-Oct-2019
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2875.58  PSIA                 :
@@ -2346,7 +2346,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.230313 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.209619 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2389,7 +2389,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.250880 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.230082 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2405,7 +2405,7 @@ Time step   55 at day 1825/5475, date = 30-Dec-2019
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2858.81  PSIA                 :
@@ -2432,7 +2432,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.273749 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.250234 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2448,7 +2448,7 @@ Time step   56 at day 1856/5475, date = 30-Jan-2020
 
 Time step 0, stepsize 28 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2851.29  PSIA                 :
@@ -2475,7 +2475,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.287138 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.263428 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2491,7 +2491,7 @@ Time step   57 at day 1884/5475, date = 27-Feb-2020
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  16 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  16 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2843.02  PSIA                 :
@@ -2518,7 +2518,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.307719 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.283365 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2561,7 +2561,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.328358 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.303189 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2604,7 +2604,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.349000 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.323720 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2620,7 +2620,7 @@ Time step   60 at day 1976/5475, date = 29-May-2020
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2818.89  PSIA                 :
@@ -2647,7 +2647,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.370928 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.343950 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2663,7 +2663,7 @@ Time step   61 at day 2006/5475, date = 28-Jun-2020
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.003 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2810.72  PSIA                 :
@@ -2690,7 +2690,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.390932 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.363659 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2706,7 +2706,7 @@ Time step   62 at day 2037/5475, date = 29-Jul-2020
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  13 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  13 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2802.54  PSIA                 :
@@ -2733,7 +2733,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.411664 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.383457 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2749,7 +2749,7 @@ Time step   63 at day 2068/5475, date = 29-Aug-2020
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  11 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.003 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2794.63  PSIA                 :
@@ -2776,7 +2776,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.432020 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.403020 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2792,7 +2792,7 @@ Time step   64 at day 2098/5475, date = 28-Sep-2020
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  11 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.003 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2786.52  PSIA                 :
@@ -2819,7 +2819,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.453591 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.422610 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2862,7 +2862,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.466837 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.435929 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2905,7 +2905,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.480152 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.449163 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2921,7 +2921,7 @@ Time step   67 at day 2190/5475, date = 29-Dec-2020
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2762.67  PSIA                 :
@@ -2948,7 +2948,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.493621 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.462670 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -2964,7 +2964,7 @@ Time step   68 at day 2221/5475, date = 29-Jan-2021
 
 Time step 0, stepsize 28 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  15 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  15 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2755.45  PSIA                 :
@@ -2991,7 +2991,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.514275 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.482733 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3034,7 +3034,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.534197 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.502517 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3050,7 +3050,7 @@ Time step   70 at day 2280/5475, date = 29-Mar-2021
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   8 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   8 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2739.81  PSIA                 :
@@ -3077,7 +3077,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.548419 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.515497 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3120,7 +3120,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.561734 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.528531 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3136,7 +3136,7 @@ Time step   72 at day 2341/5475, date = 29-May-2021
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  12 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  12 ( 0.003 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2724.29  PSIA                 :
@@ -3163,7 +3163,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.581980 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.548219 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3206,7 +3206,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.601871 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.568119 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3222,7 +3222,7 @@ Time step   74 at day 2402/5475, date = 29-Jul-2021
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2708.54  PSIA                 :
@@ -3249,7 +3249,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.615692 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.581202 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3265,7 +3265,7 @@ Time step   75 at day 2433/5475, date = 29-Aug-2021
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  15 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  15 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2700.95  PSIA                 :
@@ -3292,7 +3292,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.636668 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.601392 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3308,7 +3308,7 @@ Time step   76 at day 2463/5475, date = 28-Sep-2021
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  16 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  16 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2693.13  PSIA                 :
@@ -3335,7 +3335,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.658415 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.621420 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3351,7 +3351,7 @@ Time step   77 at day 2494/5475, date = 29-Oct-2021
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   8 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.012 sec), linear its =   8 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2685.57  PSIA                 :
@@ -3378,7 +3378,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.672163 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.636217 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3421,7 +3421,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.685675 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.650011 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3437,7 +3437,7 @@ Time step   79 at day 2555/5475, date = 29-Dec-2021
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2670.04  PSIA                 :
@@ -3464,7 +3464,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.699694 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.663147 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3507,7 +3507,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.720068 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.682954 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3523,7 +3523,7 @@ Time step   81 at day 2614/5475, date = 26-Feb-2022
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2655.34  PSIA                 :
@@ -3550,7 +3550,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.733757 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.696141 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3566,7 +3566,7 @@ Time step   82 at day 2645/5475, date = 29-Mar-2022
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.003 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2647.89  PSIA                 :
@@ -3593,7 +3593,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.749221 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.709244 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3609,7 +3609,7 @@ Time step   83 at day 2675/5475, date = 28-Apr-2022
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2640.21  PSIA                 :
@@ -3636,7 +3636,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.763056 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.722394 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3652,7 +3652,7 @@ Time step   84 at day 2706/5475, date = 29-May-2022
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2632.82  PSIA                 :
@@ -3679,7 +3679,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.776953 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.735557 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3722,7 +3722,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.790955 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.748882 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3738,7 +3738,7 @@ Time step   86 at day 2767/5475, date = 29-Jul-2022
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   7 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   7 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2617.62  PSIA                 :
@@ -3765,7 +3765,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.805235 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.762069 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3781,7 +3781,7 @@ Time step   87 at day 2798/5475, date = 29-Aug-2022
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  11 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        2610.3  PSIA                 :
@@ -3808,7 +3808,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.826049 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.781774 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3824,7 +3824,7 @@ Time step   88 at day 2828/5475, date = 28-Sep-2022
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2602.68  PSIA                 :
@@ -3851,7 +3851,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.848234 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.801886 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3894,7 +3894,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.862012 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.815077 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3910,7 +3910,7 @@ Time step   90 at day 2889/5475, date = 28-Nov-2022
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   8 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   8 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        2587.8  PSIA                 :
@@ -3937,7 +3937,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.875743 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.828181 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3953,7 +3953,7 @@ Time step   91 at day 2920/5475, date = 29-Dec-2022
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  14 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  14 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2580.25  PSIA                 :
@@ -3980,7 +3980,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.896537 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.848237 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -3996,7 +3996,7 @@ Time step   92 at day 2951/5475, date = 29-Jan-2023
 
 Time step 0, stepsize 28 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   8 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   8 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2573.45  PSIA                 :
@@ -4023,7 +4023,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.910358 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.861513 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4039,7 +4039,7 @@ Time step   93 at day 2979/5475, date = 26-Feb-2023
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   8 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   8 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2565.94  PSIA                 :
@@ -4066,7 +4066,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.923903 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.874768 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4082,7 +4082,7 @@ Time step   94 at day 3010/5475, date = 29-Mar-2023
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   8 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   8 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        2558.7  PSIA                 :
@@ -4109,7 +4109,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.938581 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.887963 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4125,7 +4125,7 @@ Time step   95 at day 3040/5475, date = 28-Apr-2023
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   8 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   8 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2551.23  PSIA                 :
@@ -4152,7 +4152,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.951972 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.901081 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4168,7 +4168,7 @@ Time step   96 at day 3071/5475, date = 29-May-2023
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.021 sec), linear its =  18 ( 0.006 sec)
+Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.020 sec), linear its =  18 ( 0.005 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2543.99  PSIA                 :
@@ -4195,7 +4195,7 @@ Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.021 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.979582 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.927859 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4211,7 +4211,7 @@ Time step   97 at day 3101/5475, date = 28-Jun-2023
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   8 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   8 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2536.52  PSIA                 :
@@ -4238,7 +4238,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.993305 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.940957 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4281,7 +4281,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.013583 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.960857 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4297,7 +4297,7 @@ Time step   99 at day 3163/5475, date = 29-Aug-2023
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   8 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   8 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2521.88  PSIA                 :
@@ -4324,7 +4324,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.027107 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.974267 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4340,7 +4340,7 @@ Time step  100 at day 3193/5475, date = 28-Sep-2023
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   8 ( 0.003 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   8 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2514.47  PSIA                 :
@@ -4367,7 +4367,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.041948 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 1.987563 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4383,7 +4383,7 @@ Time step  101 at day 3224/5475, date = 29-Oct-2023
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2507.32  PSIA                 :
@@ -4410,7 +4410,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.063058 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.008072 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4426,7 +4426,7 @@ Time step  102 at day 3254/5475, date = 28-Nov-2023
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2500.02  PSIA                 :
@@ -4453,7 +4453,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.084205 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.028453 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4469,7 +4469,7 @@ Time step  103 at day 3285/5475, date = 29-Dec-2023
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  13 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  13 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2492.79  PSIA                 :
@@ -4496,7 +4496,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.104892 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.048534 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4512,7 +4512,7 @@ Time step  104 at day 3316/5475, date = 29-Jan-2024
 
 Time step 0, stepsize 28 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.021 sec), linear its =  19 ( 0.006 sec)
+Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.020 sec), linear its =  19 ( 0.006 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2486.37  PSIA                 :
@@ -4539,7 +4539,7 @@ Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.021 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.133419 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.075251 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4555,7 +4555,7 @@ Time step  105 at day 3344/5475, date = 26-Feb-2024
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2479.35  PSIA                 :
@@ -4582,7 +4582,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.155013 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.095576 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4625,7 +4625,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.175567 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.116465 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4668,7 +4668,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.189387 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.130786 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4684,7 +4684,7 @@ Time step  108 at day 3436/5475, date = 28-May-2024
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2458.95  PSIA                 :
@@ -4711,7 +4711,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.202989 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.144082 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4727,7 +4727,7 @@ Time step  109 at day 3466/5475, date = 27-Jun-2024
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2452.05  PSIA                 :
@@ -4754,7 +4754,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.216574 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.157334 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4770,7 +4770,7 @@ Time step  110 at day 3497/5475, date = 28-Jul-2024
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2445.17  PSIA                 :
@@ -4797,7 +4797,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.230595 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.170681 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4813,7 +4813,7 @@ Time step  111 at day 3528/5475, date = 28-Aug-2024
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2438.54  PSIA                 :
@@ -4840,7 +4840,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.245458 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.184242 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4856,7 +4856,7 @@ Time step  112 at day 3558/5475, date = 27-Sep-2024
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  11 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  11 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        2431.7  PSIA                 :
@@ -4883,7 +4883,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.266225 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.204069 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4899,7 +4899,7 @@ Time step  113 at day 3589/5475, date = 28-Oct-2024
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  12 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  12 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2425.07  PSIA                 :
@@ -4926,7 +4926,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.287074 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.224190 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4942,7 +4942,7 @@ Time step  114 at day 3619/5475, date = 27-Nov-2024
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   9 ( 0.002 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   9 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2418.22  PSIA                 :
@@ -4969,7 +4969,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.300695 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.237545 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -4985,7 +4985,7 @@ Time step  115 at day 3650/5475, date = 28-Dec-2024
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2391.57  PSIA                 :
@@ -5012,7 +5012,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.321921 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.257937 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5028,7 +5028,7 @@ Time step  116 at day 3681/5475, date = 28-Jan-2025
 
 Time step 0, stepsize 28 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 sec), linear its =   8 ( 0.003 sec)
+Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.010 sec), linear its =   8 ( 0.002 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2367.47  PSIA                 :
@@ -5055,7 +5055,7 @@ Time step summary: well its =  1, newton its =  1, linearizations =  2 ( 0.011 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.336595 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.271310 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5071,7 +5071,7 @@ Time step  117 at day 3709/5475, date = 25-Feb-2025
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2340.89  PSIA                 :
@@ -5098,7 +5098,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.359024 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.291822 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5114,7 +5114,7 @@ Time step  118 at day 3740/5475, date = 28-Mar-2025
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2315.25  PSIA                 :
@@ -5141,7 +5141,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.380389 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.312282 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5157,7 +5157,7 @@ Time step  119 at day 3770/5475, date = 27-Apr-2025
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2288.84  PSIA                 :
@@ -5184,7 +5184,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.401725 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.332789 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5200,7 +5200,7 @@ Time step  120 at day 3801/5475, date = 28-May-2025
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  15 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  15 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2263.33  PSIA                 :
@@ -5227,7 +5227,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.423151 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.352954 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5243,7 +5243,7 @@ Time step  121 at day 3831/5475, date = 27-Jun-2025
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2237.06  PSIA                 :
@@ -5270,7 +5270,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.445415 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.373637 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5286,7 +5286,7 @@ Time step  122 at day 3862/5475, date = 28-Jul-2025
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2210.86  PSIA                 :
@@ -5313,7 +5313,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.467270 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.394239 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5329,7 +5329,7 @@ Time step  123 at day 3893/5475, date = 28-Aug-2025
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  20 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  20 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2185.58  PSIA                 :
@@ -5356,7 +5356,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.488708 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.414903 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5372,7 +5372,7 @@ Time step  124 at day 3923/5475, date = 27-Sep-2025
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  20 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  20 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2159.52  PSIA                 :
@@ -5399,7 +5399,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.510132 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.435441 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5415,7 +5415,7 @@ Time step  125 at day 3954/5475, date = 28-Oct-2025
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  16 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  16 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2134.38  PSIA                 :
@@ -5442,7 +5442,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.531951 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.455855 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5458,7 +5458,7 @@ Time step  126 at day 3984/5475, date = 27-Nov-2025
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2108.46  PSIA                 :
@@ -5485,7 +5485,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.552746 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.476392 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5528,7 +5528,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.573353 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.496997 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5544,7 +5544,7 @@ Time step  128 at day 4046/5475, date = 28-Jan-2026
 
 Time step 0, stepsize 28 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  16 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  16 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2059.32  PSIA                 :
@@ -5571,7 +5571,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.593984 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.517335 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5614,7 +5614,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.614490 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.537583 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5630,7 +5630,7 @@ Time step  130 at day 4105/5475, date = 28-Mar-2026
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  16 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  16 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       2008.75  PSIA                 :
@@ -5657,7 +5657,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.635849 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.557974 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5673,7 +5673,7 @@ Time step  131 at day 4135/5475, date = 27-Apr-2026
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1982.94  PSIA                 :
@@ -5700,7 +5700,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.656731 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.578321 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5716,7 +5716,7 @@ Time step  132 at day 4166/5475, date = 28-May-2026
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1957.93  PSIA                 :
@@ -5743,7 +5743,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.677301 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.599439 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5759,7 +5759,7 @@ Time step  133 at day 4196/5475, date = 27-Jun-2026
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1932.15  PSIA                 :
@@ -5786,7 +5786,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.697847 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.620912 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5802,7 +5802,7 @@ Time step  134 at day 4227/5475, date = 28-Jul-2026
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1906.44  PSIA                 :
@@ -5829,7 +5829,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.719736 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.641498 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5845,7 +5845,7 @@ Time step  135 at day 4258/5475, date = 28-Aug-2026
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1881.61  PSIA                 :
@@ -5872,7 +5872,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.741940 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.661928 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5915,7 +5915,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.762931 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.682444 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5931,7 +5931,7 @@ Time step  137 at day 4319/5475, date = 28-Oct-2026
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1831.31  PSIA                 :
@@ -5958,7 +5958,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.784073 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.703150 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -5974,7 +5974,7 @@ Time step  138 at day 4349/5475, date = 27-Nov-2026
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1805.83  PSIA                 :
@@ -6001,7 +6001,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.805763 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.723673 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6017,7 +6017,7 @@ Time step  139 at day 4380/5475, date = 28-Dec-2026
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1780.41  PSIA                 :
@@ -6044,7 +6044,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.827447 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.744269 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6087,7 +6087,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.848060 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.764329 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6130,7 +6130,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.868635 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.784644 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6173,7 +6173,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.889469 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.805426 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6216,7 +6216,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.910265 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.826345 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6232,7 +6232,7 @@ Time step  144 at day 4531/5475, date = 28-May-2027
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        1658.1  PSIA                 :
@@ -6259,7 +6259,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.931966 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.846895 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6275,7 +6275,7 @@ Time step  145 at day 4561/5475, date = 27-Jun-2027
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  16 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  16 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1632.97  PSIA                 :
@@ -6302,7 +6302,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.952879 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.867385 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6318,7 +6318,7 @@ Time step  146 at day 4592/5475, date = 28-Jul-2027
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1607.87  PSIA                 :
@@ -6345,7 +6345,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.975132 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.887750 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6361,7 +6361,7 @@ Time step  147 at day 4623/5475, date = 28-Aug-2027
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  20 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  20 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1583.63  PSIA                 :
@@ -6388,7 +6388,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.996338 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.908283 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6431,7 +6431,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.017115 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.928187 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6447,7 +6447,7 @@ Time step  149 at day 4684/5475, date = 28-Oct-2027
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1534.46  PSIA                 :
@@ -6474,7 +6474,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.038545 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.948302 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6490,7 +6490,7 @@ Time step  150 at day 4714/5475, date = 27-Nov-2027
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.018 sec), linear its =  17 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1509.54  PSIA                 :
@@ -6517,7 +6517,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.018 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.062726 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.969240 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6533,7 +6533,7 @@ Time step  151 at day 4745/5475, date = 28-Dec-2027
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1483.89  PSIA                 :
@@ -6560,7 +6560,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.084190 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.989615 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6576,7 +6576,7 @@ Time step  152 at day 4776/5475, date = 28-Jan-2028
 
 Time step 0, stepsize 28 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1460.35  PSIA                 :
@@ -6603,7 +6603,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.105454 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.009873 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6619,7 +6619,7 @@ Time step  153 at day 4804/5475, date = 25-Feb-2028
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1434.34  PSIA                 :
@@ -6646,7 +6646,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.127111 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.030299 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6662,7 +6662,7 @@ Time step  154 at day 4835/5475, date = 27-Mar-2028
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  16 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  16 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1409.22  PSIA                 :
@@ -6689,7 +6689,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.147976 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.050763 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6705,7 +6705,7 @@ Time step  155 at day 4865/5475, date = 26-Apr-2028
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        1383.3  PSIA                 :
@@ -6732,7 +6732,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.168939 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.071103 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6748,7 +6748,7 @@ Time step  156 at day 4896/5475, date = 27-May-2028
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.017 sec), linear its =  18 ( 0.005 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1358.27  PSIA                 :
@@ -6775,7 +6775,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.190000 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.093907 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6791,7 +6791,7 @@ Time step  157 at day 4926/5475, date = 26-Jun-2028
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1332.45  PSIA                 :
@@ -6818,7 +6818,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.211611 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.114539 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6834,7 +6834,7 @@ Time step  158 at day 4957/5475, date = 27-Jul-2028
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1306.67  PSIA                 :
@@ -6861,7 +6861,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.232913 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.134849 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6904,7 +6904,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.253493 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.155566 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6947,7 +6947,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.274307 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.176069 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -6990,7 +6990,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.295090 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.196575 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7006,7 +7006,7 @@ Time step  162 at day 5079/5475, date = 26-Nov-2028
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1205.63  PSIA                 :
@@ -7033,7 +7033,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.316029 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.216890 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7049,7 +7049,7 @@ Time step  163 at day 5110/5475, date = 27-Dec-2028
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  19 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  19 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1180.04  PSIA                 :
@@ -7076,7 +7076,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.336999 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.237532 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7119,7 +7119,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.357616 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.258261 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7162,7 +7162,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.378447 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.278740 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7178,7 +7178,7 @@ Time step  166 at day 5200/5475, date = 27-Mar-2029
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  18 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        1106.8  PSIA                 :
@@ -7205,7 +7205,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.399861 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.299307 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7248,7 +7248,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.421053 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.319755 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7264,7 +7264,7 @@ Time step  168 at day 5261/5475, date = 27-May-2029
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.005 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  18 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       1056.76  PSIA                 :
@@ -7291,7 +7291,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.442179 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.340394 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7334,7 +7334,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.462716 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.361040 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7377,7 +7377,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.482926 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.381385 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7420,7 +7420,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.503334 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.401706 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7436,7 +7436,7 @@ Time step  172 at day 5383/5475, date = 26-Sep-2029
 
 Time step 0, stepsize 31 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  17 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  17 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       952.535  PSIA                 :
@@ -7463,7 +7463,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.523998 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.421940 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7479,7 +7479,7 @@ Time step  173 at day 5414/5475, date = 27-Oct-2029
 
 Time step 0, stepsize 30 days.
 well converged iter: 1
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 sec), linear its =  16 ( 0.004 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.016 sec), linear its =  16 ( 0.004 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        926.04  PSIA                 :
@@ -7506,7 +7506,7 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.544569 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.442619 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -7549,19 +7549,19 @@ Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.015 s
 :Originally  in place    :             0       3797199       3797199:      5640574   :      22730662             0      22730662:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.564944 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.463228 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
 
 ================    End of simulation     ===============
 
-Total time (seconds):         3.68558
-Solver time (seconds):        3.56494
- Assembly time (seconds):     2.68309
- Linear solve time (seconds): 0.678424
- Update time (seconds):       0.111027
- Output write time (seconds): 0.0247344
+Total time (seconds):         3.57293
+Solver time (seconds):        3.46323
+ Assembly time (seconds):     2.60423
+ Linear solve time (seconds): 0.661616
+ Update time (seconds):       0.103302
+ Output write time (seconds): 0.0221547
 Overall Well Iterations:      179
 Overall Linearizations:       511
 Overall Newton Iterations:    332

--- a/spe9/opm-simulation-reference/flow/SPE9_CP_SHORT.PRT
+++ b/spe9/opm-simulation-reference/flow/SPE9_CP_SHORT.PRT
@@ -10,10 +10,10 @@
 Flow is a simulator for fully implicit three-phase black-oil flow, and is part of OPM.
 For more information visit: https://opm-project.org 
 
-Flow Version  =  2018.04-pre
+Flow Version  =  2018.10-pre
 System        =  opm-deb (Number of cores: 12, RAM: 32178.65 MB) 
 Architecture  =  Linux x86_64 (Release: 4.9.0-3-amd64, Version: #1 SMP Debian 4.9.30-2+deb9u2 (2017-06-26) )
-Simulation started on 23-04-2018 at 13:04:30 hrs
+Simulation started on 08-05-2018 at 08:08:48 hrs
 
 
 ===============Saturation Functions Diagnostics===============
@@ -57,20 +57,20 @@ Report step  0/21 at day 0/210, date = 01-Jan-2015
 
 Time step 0, stepsize 1 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
-Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.269 sec), linear its =  18 ( 0.100 sec)
+Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.266 sec), linear its =  18 ( 0.093 sec)
 
 Time step 1, stepsize 3 days.
     Switching control mode for well PRODU21 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
-Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.247 sec), linear its =  23 ( 0.113 sec)
+Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.237 sec), linear its =  23 ( 0.103 sec)
 
 Time step 2, stepsize 6 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
-Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.245 sec), linear its =  22 ( 0.109 sec)
+Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.243 sec), linear its =  22 ( 0.101 sec)
 
                               **************************************************************************
   Balance  at        10  Days *                         SPE 9                                          *
-  Report    1    11 Jan 2015  *                                             Flow  version 2018.04-pre  *
+  Report    1    11 Jan 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -109,11 +109,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU21 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.315 sec), linear its =  24 ( 0.131 sec)
+Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.313 sec), linear its =  24 ( 0.118 sec)
 
                               **************************************************************************
   Balance  at        20  Days *                         SPE 9                                          *
-  Report    2    21 Jan 2015  *                                             Flow  version 2018.04-pre  *
+  Report    2    21 Jan 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -152,11 +152,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU21 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.247 sec), linear its =  20 ( 0.104 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.243 sec), linear its =  20 ( 0.096 sec)
 
                               **************************************************************************
   Balance  at        30  Days *                         SPE 9                                          *
-  Report    3    31 Jan 2015  *                                             Flow  version 2018.04-pre  *
+  Report    3    31 Jan 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -197,11 +197,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
     Switching control mode for well PRODU9 from SURFACE_RATE to BHP
     Switching control mode for well PRODU9 from BHP to SURFACE_RATE
-Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.317 sec), linear its =  22 ( 0.124 sec)
+Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.312 sec), linear its =  22 ( 0.112 sec)
 
                               **************************************************************************
   Balance  at        40  Days *                         SPE 9                                          *
-  Report    4    10 Feb 2015  *                                             Flow  version 2018.04-pre  *
+  Report    4    10 Feb 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -240,11 +240,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU21 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.247 sec), linear its =  16 ( 0.092 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.243 sec), linear its =  16 ( 0.084 sec)
 
                               **************************************************************************
   Balance  at        50  Days *                         SPE 9                                          *
-  Report    5    20 Feb 2015  *                                             Flow  version 2018.04-pre  *
+  Report    5    20 Feb 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -283,11 +283,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU21 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.248 sec), linear its =  15 ( 0.089 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.240 sec), linear its =  15 ( 0.080 sec)
 
                               **************************************************************************
   Balance  at        60  Days *                         SPE 9                                          *
-  Report    6    02 Mar 2015  *                                             Flow  version 2018.04-pre  *
+  Report    6    02 Mar 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -326,11 +326,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU21 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.246 sec), linear its =  16 ( 0.090 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.245 sec), linear its =  16 ( 0.083 sec)
 
                               **************************************************************************
   Balance  at        70  Days *                         SPE 9                                          *
-  Report    7    12 Mar 2015  *                                             Flow  version 2018.04-pre  *
+  Report    7    12 Mar 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -370,11 +370,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
     Switching control mode for well PRODU9 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.181 sec), linear its =  11 ( 0.063 sec)
+Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.174 sec), linear its =  11 ( 0.056 sec)
 
                               **************************************************************************
   Balance  at        80  Days *                         SPE 9                                          *
-  Report    8    22 Mar 2015  *                                             Flow  version 2018.04-pre  *
+  Report    8    22 Mar 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -414,11 +414,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
     Switching control mode for well PRODU9 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.250 sec), linear its =  15 ( 0.088 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.245 sec), linear its =  15 ( 0.080 sec)
 
                               **************************************************************************
   Balance  at        90  Days *                         SPE 9                                          *
-  Report    9    01 Apr 2015  *                                             Flow  version 2018.04-pre  *
+  Report    9    01 Apr 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -458,11 +458,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU21 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.241 sec), linear its =  17 ( 0.093 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.242 sec), linear its =  17 ( 0.088 sec)
 
                               **************************************************************************
   Balance  at       100  Days *                         SPE 9                                          *
-  Report   10    11 Apr 2015  *                                             Flow  version 2018.04-pre  *
+  Report   10    11 Apr 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -498,11 +498,11 @@ Report step 10/21 at day 100/210, date = 11-Apr-2015
 
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.306 sec), linear its =  18 ( 0.107 sec)
+Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.309 sec), linear its =  18 ( 0.100 sec)
 
                               **************************************************************************
   Balance  at       110  Days *                         SPE 9                                          *
-  Report   11    21 Apr 2015  *                                             Flow  version 2018.04-pre  *
+  Report   11    21 Apr 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -538,11 +538,11 @@ Report step 11/21 at day 110/210, date = 21-Apr-2015
 
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.255 sec), linear its =  16 ( 0.097 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.239 sec), linear its =  16 ( 0.086 sec)
 
                               **************************************************************************
   Balance  at       120  Days *                         SPE 9                                          *
-  Report   12    01 May 2015  *                                             Flow  version 2018.04-pre  *
+  Report   12    01 May 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -578,11 +578,11 @@ Report step 12/21 at day 120/210, date = 01-May-2015
 
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.269 sec), linear its =  15 ( 0.084 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.239 sec), linear its =  15 ( 0.079 sec)
 
                               **************************************************************************
   Balance  at       130  Days *                         SPE 9                                          *
-  Report   13    11 May 2015  *                                             Flow  version 2018.04-pre  *
+  Report   13    11 May 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -618,11 +618,11 @@ Report step 13/21 at day 130/210, date = 11-May-2015
 
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.248 sec), linear its =  15 ( 0.093 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.240 sec), linear its =  15 ( 0.077 sec)
 
                               **************************************************************************
   Balance  at       140  Days *                         SPE 9                                          *
-  Report   14    21 May 2015  *                                             Flow  version 2018.04-pre  *
+  Report   14    21 May 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -658,11 +658,11 @@ Report step 14/21 at day 140/210, date = 21-May-2015
 
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.250 sec), linear its =  15 ( 0.092 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.238 sec), linear its =  15 ( 0.081 sec)
 
                               **************************************************************************
   Balance  at       150  Days *                         SPE 9                                          *
-  Report   15    31 May 2015  *                                             Flow  version 2018.04-pre  *
+  Report   15    31 May 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -698,11 +698,11 @@ Report step 15/21 at day 150/210, date = 31-May-2015
 
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.246 sec), linear its =  15 ( 0.085 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.238 sec), linear its =  15 ( 0.079 sec)
 
                               **************************************************************************
   Balance  at       160  Days *                         SPE 9                                          *
-  Report   16    10 Jun 2015  *                                             Flow  version 2018.04-pre  *
+  Report   16    10 Jun 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -741,11 +741,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
     Switching control mode for well PRODU21 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  5, linearizations =  6 ( 0.411 sec), linear its =  18 ( 0.125 sec)
+Time step summary: well its =  2, newton its =  5, linearizations =  6 ( 0.373 sec), linear its =  18 ( 0.115 sec)
 
                               **************************************************************************
   Balance  at       170  Days *                         SPE 9                                          *
-  Report   17    20 Jun 2015  *                                             Flow  version 2018.04-pre  *
+  Report   17    20 Jun 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -785,11 +785,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
     Switching control mode for well PRODU9 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  5, linearizations =  6 ( 0.389 sec), linear its =  21 ( 0.133 sec)
+Time step summary: well its =  2, newton its =  5, linearizations =  6 ( 0.369 sec), linear its =  21 ( 0.125 sec)
 
                               **************************************************************************
   Balance  at       180  Days *                         SPE 9                                          *
-  Report   18    30 Jun 2015  *                                             Flow  version 2018.04-pre  *
+  Report   18    30 Jun 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -830,11 +830,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
     Switching control mode for well PRODU22 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.246 sec), linear its =  18 ( 0.095 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.238 sec), linear its =  18 ( 0.089 sec)
 
                               **************************************************************************
   Balance  at       190  Days *                         SPE 9                                          *
-  Report   19    10 Jul 2015  *                                             Flow  version 2018.04-pre  *
+  Report   19    10 Jul 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -876,11 +876,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
     Switching control mode for well PRODU16 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.236 sec), linear its =  17 ( 0.089 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.241 sec), linear its =  17 ( 0.087 sec)
 
                               **************************************************************************
   Balance  at       200  Days *                         SPE 9                                          *
-  Report   20    20 Jul 2015  *                                             Flow  version 2018.04-pre  *
+  Report   20    20 Jul 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -922,11 +922,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU22 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.253 sec), linear its =  16 ( 0.087 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.238 sec), linear its =  16 ( 0.082 sec)
 
                               **************************************************************************
   Balance  at       210  Days *                         SPE 9                                          *
-  Report   21    30 Jul 2015  *                                             Flow  version 2018.04-pre  *
+  Report   21    30 Jul 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -961,12 +961,12 @@ Warning: Keyword 'BASIC' is unhandled for output to file.
 
 ================    End of simulation     ===============
 
-Total time (seconds):         8.98216
-Solver time (seconds):        8.89696
- Assembly time (seconds):     6.16346 (Failed: 0; 0%)
- Linear solve time (seconds): 2.28139 (Failed: 0; 0%)
- Update time (seconds):       0.283651 (Failed: 0; 0%)
- Output write time (seconds): 0.0914061
+Total time (seconds):         8.57576
+Solver time (seconds):        8.49557
+ Assembly time (seconds):     5.96404 (Failed: 0; 0%)
+ Linear solve time (seconds): 2.09507 (Failed: 0; 0%)
+ Update time (seconds):       0.271674 (Failed: 0; 0%)
+ Output write time (seconds): 0.0855985
 Overall Well Iterations:      43 (Failed: 0; 0%)
 Overall Linearizations:       98 (Failed: 0; 0%)
 Overall Newton Iterations:    75 (Failed: 0; 0%)

--- a/spe9/opm-simulation-reference/flow_legacy/SPE9_CP_SHORT.PRT
+++ b/spe9/opm-simulation-reference/flow_legacy/SPE9_CP_SHORT.PRT
@@ -24,18 +24,18 @@ Time step    0 at day 0/210, date = 01-Jan-2015
 Time step 0, stepsize 1 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.510 sec), linear its =  15 ( 0.142 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.511 sec), linear its =  15 ( 0.141 sec)
 
 Time step 1, stepsize 3 days.
 well converged iter: 1
     Switching control mode for well PRODU21 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
-Time step summary: well its =  1, newton its =  4, linearizations =  5 ( 0.644 sec), linear its =  24 ( 0.221 sec)
+Time step summary: well its =  1, newton its =  4, linearizations =  5 ( 0.611 sec), linear its =  24 ( 0.195 sec)
 
 Time step 2, stepsize 6 days.
 well converged iter: 1
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
-Time step summary: well its =  1, newton its =  4, linearizations =  5 ( 0.640 sec), linear its =  27 ( 0.210 sec)
+Time step summary: well its =  1, newton its =  4, linearizations =  5 ( 0.612 sec), linear its =  27 ( 0.203 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3778.73  PSIA                 :
@@ -62,7 +62,7 @@ Time step summary: well its =  1, newton its =  4, linearizations =  5 ( 0.640 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.409843 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 2.315384 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -82,7 +82,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.619 sec), linear its =  26 ( 0.200 sec)
+Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.615 sec), linear its =  26 ( 0.196 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        3752.6  PSIA                 :
@@ -109,7 +109,7 @@ Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.619 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.249186 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.144820 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -129,7 +129,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.496 sec), linear its =  19 ( 0.150 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.491 sec), linear its =  19 ( 0.146 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3729.91  PSIA                 :
@@ -156,7 +156,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.496 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.914593 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 3.799390 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -178,7 +178,7 @@ Time step 0, stepsize 10 days.
 well converged iter: 2
     Switching control mode for well PRODU9 from SURFACE_RATE to BHP
     Switching control mode for well PRODU9 from BHP to SURFACE_RATE
-Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.615 sec), linear its =  21 ( 0.202 sec)
+Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.608 sec), linear its =  21 ( 0.181 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3709.34  PSIA                 :
@@ -205,7 +205,7 @@ Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.615 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 4.751334 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 4.607766 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -225,7 +225,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.494 sec), linear its =  16 ( 0.144 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.500 sec), linear its =  16 ( 0.140 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3690.14  PSIA                 :
@@ -252,7 +252,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.494 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 5.407613 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 5.265344 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -272,7 +272,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.493 sec), linear its =  16 ( 0.143 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.490 sec), linear its =  16 ( 0.140 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3671.66  PSIA                 :
@@ -299,7 +299,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.493 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 6.060815 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 5.912337 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -319,7 +319,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.498 sec), linear its =  20 ( 0.150 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.488 sec), linear its =  20 ( 0.146 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3653.57  PSIA                 :
@@ -346,7 +346,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.498 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 6.726003 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 6.564380 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -367,7 +367,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
     Switching control mode for well PRODU9 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.492 sec), linear its =  18 ( 0.145 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.486 sec), linear its =  18 ( 0.141 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3635.63  PSIA                 :
@@ -394,7 +394,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.492 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 7.381188 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 7.209884 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -415,7 +415,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
     Switching control mode for well PRODU9 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.490 sec), linear its =  15 ( 0.138 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.488 sec), linear its =  15 ( 0.135 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3617.73  PSIA                 :
@@ -442,7 +442,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.490 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 8.026385 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 7.850746 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -463,7 +463,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.489 sec), linear its =  18 ( 0.147 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.485 sec), linear its =  18 ( 0.139 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3599.82  PSIA                 :
@@ -490,7 +490,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.489 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 8.680646 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 8.492172 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -507,7 +507,7 @@ Time step   10 at day 100/210, date = 11-Apr-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  5, linearizations =  6 ( 0.759 sec), linear its =  20 ( 0.224 sec)
+Time step summary: well its =  2, newton its =  5, linearizations =  6 ( 0.729 sec), linear its =  20 ( 0.215 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3593.38  PSIA                 :
@@ -534,7 +534,7 @@ Time step summary: well its =  2, newton its =  5, linearizations =  6 ( 0.759 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 9.686553 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 9.458211 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -551,7 +551,7 @@ Time step   11 at day 110/210, date = 21-Apr-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.495 sec), linear its =  17 ( 0.139 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.495 sec), linear its =  17 ( 0.141 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3588.05  PSIA                 :
@@ -578,7 +578,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.495 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 10.338554 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 10.112070 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -595,7 +595,7 @@ Time step   12 at day 120/210, date = 01-May-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.508 sec), linear its =  15 ( 0.133 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.494 sec), linear its =  15 ( 0.137 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3583.55  PSIA                 :
@@ -622,7 +622,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.508 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 10.998781 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 10.760981 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -639,7 +639,7 @@ Time step   13 at day 130/210, date = 11-May-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.498 sec), linear its =  12 ( 0.130 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.496 sec), linear its =  12 ( 0.131 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3579.62  PSIA                 :
@@ -666,7 +666,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.498 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 11.645936 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 11.406686 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -683,7 +683,7 @@ Time step   14 at day 140/210, date = 21-May-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.495 sec), linear its =  14 ( 0.135 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.501 sec), linear its =  14 ( 0.137 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =        3576.2  PSIA                 :
@@ -710,7 +710,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.495 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 12.293505 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 12.063345 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -727,7 +727,7 @@ Time step   15 at day 150/210, date = 31-May-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.495 sec), linear its =  12 ( 0.129 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.509 sec), linear its =  12 ( 0.132 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3573.19  PSIA                 :
@@ -754,7 +754,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.495 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 12.935115 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 12.723223 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -774,7 +774,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
     Switching control mode for well PRODU21 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  6, linearizations =  7 ( 0.883 sec), linear its =  16 ( 0.252 sec)
+Time step summary: well its =  2, newton its =  6, linearizations =  7 ( 0.875 sec), linear its =  16 ( 0.248 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3561.57  PSIA                 :
@@ -801,7 +801,7 @@ Time step summary: well its =  2, newton its =  6, linearizations =  7 ( 0.883 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 14.094886 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 13.870830 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -822,7 +822,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
     Switching control mode for well PRODU9 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  5, linearizations =  6 ( 0.829 sec), linear its =  19 ( 0.238 sec)
+Time step summary: well its =  2, newton its =  5, linearizations =  6 ( 0.754 sec), linear its =  19 ( 0.226 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3549.68  PSIA                 :
@@ -849,7 +849,7 @@ Time step summary: well its =  2, newton its =  5, linearizations =  6 ( 0.829 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 15.186106 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 14.872706 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -871,7 +871,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
     Switching control mode for well PRODU22 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.532 sec), linear its =  15 ( 0.154 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.502 sec), linear its =  15 ( 0.136 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3536.49  PSIA                 :
@@ -898,7 +898,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.532 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 15.891022 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 15.528873 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -921,7 +921,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
     Switching control mode for well PRODU16 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.527 sec), linear its =  14 ( 0.144 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.497 sec), linear its =  14 ( 0.135 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3522.11  PSIA                 :
@@ -948,7 +948,7 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.527 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 16.581724 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 16.179251 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
@@ -971,7 +971,7 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
     Switching control mode for well PRODU26 from SURFACE_RATE to BHP
 well converged iter: 2
-Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.533 sec), linear its =  15 ( 0.142 sec)
+Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.502 sec), linear its =  15 ( 0.137 sec)
                                                   ===================================================
                                                   :                   Field Totals                  :
                                                   :      PAV  =       3506.83  PSIA                 :
@@ -998,19 +998,19 @@ Time step summary: well its =  2, newton its =  3, linearizations =  4 ( 0.533 s
 :Originally  in place    :     217546282             0     217546282:    212389812   :             0     302387412     302387412:
 :========================:==========================================:================:==========================================:
 
-Fully implicit solver took: 0.000000 seconds. Total solver time taken: 17.277597 seconds.
+Fully implicit solver took: 0.000000 seconds. Total solver time taken: 16.836496 seconds.
 
 Warning: Keyword 'BASIC' is unhandled for output to file.
 
 
 ================    End of simulation     ===============
 
-Total time (seconds):         17.4988
-Solver time (seconds):        17.2776
- Assembly time (seconds):     13.0339
- Linear solve time (seconds): 3.81321
- Update time (seconds):       0.164377
- Output write time (seconds): 0.0369206
+Total time (seconds):         17.0366
+Solver time (seconds):        16.8365
+ Assembly time (seconds):     12.7375
+ Linear solve time (seconds): 3.67507
+ Update time (seconds):       0.163407
+ Output write time (seconds): 0.0354638
 Overall Well Iterations:      44
 Overall Linearizations:       103
 Overall Newton Iterations:    80

--- a/spe9group/opm-simulation-reference/flow/SPE9_CP_GROUP.PRT
+++ b/spe9group/opm-simulation-reference/flow/SPE9_CP_GROUP.PRT
@@ -10,10 +10,10 @@
 Flow is a simulator for fully implicit three-phase black-oil flow, and is part of OPM.
 For more information visit: https://opm-project.org 
 
-Flow Version  =  2018.04-pre
+Flow Version  =  2018.10-pre
 System        =  opm-deb (Number of cores: 12, RAM: 32178.65 MB) 
 Architecture  =  Linux x86_64 (Release: 4.9.0-3-amd64, Version: #1 SMP Debian 4.9.30-2+deb9u2 (2017-06-26) )
-Simulation started on 23-04-2018 at 13:04:58 hrs
+Simulation started on 08-05-2018 at 08:09:14 hrs
 
 
 ===============Saturation Functions Diagnostics===============
@@ -57,17 +57,17 @@ Report step  0/30 at day 0/300, date = 01-Jan-2015
 
 Time step 0, stepsize 1 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
-Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.280 sec), linear its =  11 ( 0.079 sec)
+Time step summary: well its =  1, newton its =  3, linearizations =  4 ( 0.255 sec), linear its =  11 ( 0.070 sec)
 
 Time step 1, stepsize 3 days.
-Time step summary: newton its =  2, linearizations =  3 ( 0.176 sec), linear its =  12 ( 0.064 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.167 sec), linear its =  12 ( 0.061 sec)
 
 Time step 2, stepsize 6 days.
-Time step summary: newton its =  2, linearizations =  3 ( 0.175 sec), linear its =  13 ( 0.066 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.174 sec), linear its =  13 ( 0.065 sec)
 
                               **************************************************************************
   Balance  at        10  Days *                         SPE 9                                          *
-  Report    1    11 Jan 2015  *                                             Flow  version 2018.04-pre  *
+  Report    1    11 Jan 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -103,11 +103,11 @@ Report step  1/30 at day 10/300, date = 11-Jan-2015
 
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.182 sec), linear its =  15 ( 0.076 sec)
+Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.173 sec), linear its =  15 ( 0.069 sec)
 
                               **************************************************************************
   Balance  at        20  Days *                         SPE 9                                          *
-  Report    2    21 Jan 2015  *                                             Flow  version 2018.04-pre  *
+  Report    2    21 Jan 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -144,11 +144,11 @@ Report step  2/30 at day 20/300, date = 21-Jan-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.319 sec), linear its =  15 ( 0.101 sec)
+Time step summary: well its =  2, newton its =  4, linearizations =  5 ( 0.301 sec), linear its =  15 ( 0.092 sec)
 
                               **************************************************************************
   Balance  at        30  Days *                         SPE 9                                          *
-  Report    3    31 Jan 2015  *                                             Flow  version 2018.04-pre  *
+  Report    3    31 Jan 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -185,11 +185,11 @@ Report step  3/30 at day 30/300, date = 31-Jan-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.183 sec), linear its =  12 ( 0.067 sec)
+Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.177 sec), linear its =  12 ( 0.060 sec)
 
                               **************************************************************************
   Balance  at        40  Days *                         SPE 9                                          *
-  Report    4    10 Feb 2015  *                                             Flow  version 2018.04-pre  *
+  Report    4    10 Feb 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -226,11 +226,11 @@ Report step  4/30 at day 40/300, date = 10-Feb-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.177 sec), linear its =  16 ( 0.080 sec)
+Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.174 sec), linear its =  16 ( 0.071 sec)
 
                               **************************************************************************
   Balance  at        50  Days *                         SPE 9                                          *
-  Report    5    20 Feb 2015  *                                             Flow  version 2018.04-pre  *
+  Report    5    20 Feb 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -267,11 +267,11 @@ Report step  5/30 at day 50/300, date = 20-Feb-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.174 sec), linear its =  13 ( 0.067 sec)
+Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.171 sec), linear its =  13 ( 0.061 sec)
 
                               **************************************************************************
   Balance  at        60  Days *                         SPE 9                                          *
-  Report    6    02 Mar 2015  *                                             Flow  version 2018.04-pre  *
+  Report    6    02 Mar 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -308,11 +308,11 @@ Report step  6/30 at day 60/300, date = 02-Mar-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.175 sec), linear its =  15 ( 0.073 sec)
+Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.169 sec), linear its =  15 ( 0.067 sec)
 
                               **************************************************************************
   Balance  at        70  Days *                         SPE 9                                          *
-  Report    7    12 Mar 2015  *                                             Flow  version 2018.04-pre  *
+  Report    7    12 Mar 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -349,11 +349,11 @@ Report step  7/30 at day 70/300, date = 12-Mar-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.181 sec), linear its =  12 ( 0.068 sec)
+Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.169 sec), linear its =  12 ( 0.060 sec)
 
                               **************************************************************************
   Balance  at        80  Days *                         SPE 9                                          *
-  Report    8    22 Mar 2015  *                                             Flow  version 2018.04-pre  *
+  Report    8    22 Mar 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -390,11 +390,11 @@ Report step  8/30 at day 80/300, date = 22-Mar-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.187 sec), linear its =  14 ( 0.077 sec)
+Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.175 sec), linear its =  14 ( 0.068 sec)
 
                               **************************************************************************
   Balance  at        90  Days *                         SPE 9                                          *
-  Report    9    01 Apr 2015  *                                             Flow  version 2018.04-pre  *
+  Report    9    01 Apr 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -431,11 +431,11 @@ Report step  9/30 at day 90/300, date = 01-Apr-2015
 Time step 0, stepsize 10 days.
     Switching control mode for well INJE1 from SURFACE_RATE to BHP
     Switching control mode for well PRODU23 from SURFACE_RATE to BHP
-Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.180 sec), linear its =  13 ( 0.072 sec)
+Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.171 sec), linear its =  13 ( 0.063 sec)
 
                               **************************************************************************
   Balance  at       100  Days *                         SPE 9                                          *
-  Report   10    11 Apr 2015  *                                             Flow  version 2018.04-pre  *
+  Report   10    11 Apr 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -480,11 +480,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from BHP to SURFACE_RATE
 group F can not meet its target!
 group F can not meet its target!
-Time step summary: well its =  5, newton its =  2, linearizations =  3 ( 0.181 sec), linear its =  14 ( 0.071 sec)
+Time step summary: well its =  5, newton its =  2, linearizations =  3 ( 0.175 sec), linear its =  14 ( 0.067 sec)
 
                               **************************************************************************
   Balance  at       110  Days *                         SPE 9                                          *
-  Report   11    21 Apr 2015  *                                             Flow  version 2018.04-pre  *
+  Report   11    21 Apr 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -527,11 +527,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
 group F can not meet its target!
 group F can not meet its target!
-Time step summary: well its =  3, newton its =  2, linearizations =  3 ( 0.174 sec), linear its =  16 ( 0.079 sec)
+Time step summary: well its =  3, newton its =  2, linearizations =  3 ( 0.173 sec), linear its =  16 ( 0.075 sec)
 
                               **************************************************************************
   Balance  at       120  Days *                         SPE 9                                          *
-  Report   12    01 May 2015  *                                             Flow  version 2018.04-pre  *
+  Report   12    01 May 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -574,11 +574,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
 group F can not meet its target!
 group F can not meet its target!
-Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.181 sec), linear its =  17 ( 0.085 sec)
+Time step summary: well its =  2, newton its =  2, linearizations =  3 ( 0.180 sec), linear its =  17 ( 0.081 sec)
 
                               **************************************************************************
   Balance  at       130  Days *                         SPE 9                                          *
-  Report   13    11 May 2015  *                                             Flow  version 2018.04-pre  *
+  Report   13    11 May 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -621,11 +621,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
 group F can not meet its target!
 group F can not meet its target!
-Time step summary: newton its =  2, linearizations =  3 ( 0.185 sec), linear its =  19 ( 0.094 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.177 sec), linear its =  19 ( 0.083 sec)
 
                               **************************************************************************
   Balance  at       140  Days *                         SPE 9                                          *
-  Report   14    21 May 2015  *                                             Flow  version 2018.04-pre  *
+  Report   14    21 May 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -668,11 +668,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
 group F can not meet its target!
 group F can not meet its target!
-Time step summary: newton its =  2, linearizations =  3 ( 0.183 sec), linear its =  17 ( 0.085 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.175 sec), linear its =  17 ( 0.075 sec)
 
                               **************************************************************************
   Balance  at       150  Days *                         SPE 9                                          *
-  Report   15    31 May 2015  *                                             Flow  version 2018.04-pre  *
+  Report   15    31 May 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -715,11 +715,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
 group F can not meet its target!
 group F can not meet its target!
-Time step summary: newton its =  2, linearizations =  3 ( 0.197 sec), linear its =  17 ( 0.087 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.178 sec), linear its =  17 ( 0.078 sec)
 
                               **************************************************************************
   Balance  at       160  Days *                         SPE 9                                          *
-  Report   16    10 Jun 2015  *                                             Flow  version 2018.04-pre  *
+  Report   16    10 Jun 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -762,11 +762,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
 group F can not meet its target!
 group F can not meet its target!
-Time step summary: newton its =  2, linearizations =  3 ( 0.185 sec), linear its =  17 ( 0.085 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.186 sec), linear its =  17 ( 0.084 sec)
 
                               **************************************************************************
   Balance  at       170  Days *                         SPE 9                                          *
-  Report   17    20 Jun 2015  *                                             Flow  version 2018.04-pre  *
+  Report   17    20 Jun 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -809,11 +809,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
 group F can not meet its target!
 group F can not meet its target!
-Time step summary: newton its =  2, linearizations =  3 ( 0.182 sec), linear its =  17 ( 0.086 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.175 sec), linear its =  17 ( 0.077 sec)
 
                               **************************************************************************
   Balance  at       180  Days *                         SPE 9                                          *
-  Report   18    30 Jun 2015  *                                             Flow  version 2018.04-pre  *
+  Report   18    30 Jun 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -856,11 +856,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
 group F can not meet its target!
 group F can not meet its target!
-Time step summary: newton its =  2, linearizations =  3 ( 0.183 sec), linear its =  17 ( 0.086 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.178 sec), linear its =  17 ( 0.078 sec)
 
                               **************************************************************************
   Balance  at       190  Days *                         SPE 9                                          *
-  Report   19    10 Jul 2015  *                                             Flow  version 2018.04-pre  *
+  Report   19    10 Jul 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -903,11 +903,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
 group F can not meet its target!
 group F can not meet its target!
-Time step summary: newton its =  2, linearizations =  3 ( 0.201 sec), linear its =  18 ( 0.087 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.176 sec), linear its =  18 ( 0.079 sec)
 
                               **************************************************************************
   Balance  at       200  Days *                         SPE 9                                          *
-  Report   20    20 Jul 2015  *                                             Flow  version 2018.04-pre  *
+  Report   20    20 Jul 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -948,11 +948,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU9 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU15 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.176 sec), linear its =  16 ( 0.077 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.177 sec), linear its =  16 ( 0.074 sec)
 
                               **************************************************************************
   Balance  at       210  Days *                         SPE 9                                          *
-  Report   21    30 Jul 2015  *                                             Flow  version 2018.04-pre  *
+  Report   21    30 Jul 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -993,11 +993,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU9 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU15 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.205 sec), linear its =  11 ( 0.062 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.177 sec), linear its =  11 ( 0.058 sec)
 
                               **************************************************************************
   Balance  at       220  Days *                         SPE 9                                          *
-  Report   22    09 Aug 2015  *                                             Flow  version 2018.04-pre  *
+  Report   22    09 Aug 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1038,11 +1038,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU9 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU15 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.186 sec), linear its =  14 ( 0.078 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.180 sec), linear its =  14 ( 0.069 sec)
 
                               **************************************************************************
   Balance  at       230  Days *                         SPE 9                                          *
-  Report   23    19 Aug 2015  *                                             Flow  version 2018.04-pre  *
+  Report   23    19 Aug 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1083,11 +1083,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU9 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU15 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.179 sec), linear its =  11 ( 0.064 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.179 sec), linear its =  11 ( 0.060 sec)
 
                               **************************************************************************
   Balance  at       240  Days *                         SPE 9                                          *
-  Report   24    29 Aug 2015  *                                             Flow  version 2018.04-pre  *
+  Report   24    29 Aug 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1128,11 +1128,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU9 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU15 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.177 sec), linear its =  11 ( 0.061 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.179 sec), linear its =  11 ( 0.059 sec)
 
                               **************************************************************************
   Balance  at       250  Days *                         SPE 9                                          *
-  Report   25    08 Sep 2015  *                                             Flow  version 2018.04-pre  *
+  Report   25    08 Sep 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1173,11 +1173,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU9 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU15 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
-Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.186 sec), linear its =   9 ( 0.055 sec)
+Time step summary: well its =  1, newton its =  2, linearizations =  3 ( 0.173 sec), linear its =   9 ( 0.050 sec)
 
                               **************************************************************************
   Balance  at       260  Days *                         SPE 9                                          *
-  Report   26    18 Sep 2015  *                                             Flow  version 2018.04-pre  *
+  Report   26    18 Sep 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1218,11 +1218,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU9 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU15 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
-Time step summary: newton its =  2, linearizations =  3 ( 0.185 sec), linear its =   9 ( 0.057 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.174 sec), linear its =   9 ( 0.050 sec)
 
                               **************************************************************************
   Balance  at       270  Days *                         SPE 9                                          *
-  Report   27    28 Sep 2015  *                                             Flow  version 2018.04-pre  *
+  Report   27    28 Sep 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1263,11 +1263,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU9 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU15 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
-Time step summary: newton its =  2, linearizations =  3 ( 0.194 sec), linear its =  12 ( 0.070 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.176 sec), linear its =  12 ( 0.064 sec)
 
                               **************************************************************************
   Balance  at       280  Days *                         SPE 9                                          *
-  Report   28    08 Oct 2015  *                                             Flow  version 2018.04-pre  *
+  Report   28    08 Oct 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1308,11 +1308,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU9 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU15 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
-Time step summary: newton its =  2, linearizations =  3 ( 0.182 sec), linear its =  14 ( 0.070 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.174 sec), linear its =  14 ( 0.069 sec)
 
                               **************************************************************************
   Balance  at       290  Days *                         SPE 9                                          *
-  Report   29    18 Oct 2015  *                                             Flow  version 2018.04-pre  *
+  Report   29    18 Oct 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1353,11 +1353,11 @@ Time step 0, stepsize 10 days.
     Switching control mode for well PRODU9 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU15 from SURFACE_RATE to SURFACE_RATE
     Switching control mode for well PRODU23 from SURFACE_RATE to SURFACE_RATE
-Time step summary: newton its =  2, linearizations =  3 ( 0.195 sec), linear its =  14 ( 0.072 sec)
+Time step summary: newton its =  2, linearizations =  3 ( 0.176 sec), linear its =  14 ( 0.066 sec)
 
                               **************************************************************************
   Balance  at       300  Days *                         SPE 9                                          *
-  Report   30    28 Oct 2015  *                                             Flow  version 2018.04-pre  *
+  Report   30    28 Oct 2015  *                                             Flow  version 2018.10-pre  *
                               **************************************************************************
 
 
@@ -1392,12 +1392,12 @@ Warning: Keyword 'BASIC' is unhandled for output to file.
 
 ================    End of simulation     ===============
 
-Total time (seconds):         9.15967
-Solver time (seconds):        9.02916
- Assembly time (seconds):     6.10604 (Failed: 0; 0%)
- Linear solve time (seconds): 2.40111 (Failed: 0; 0%)
- Update time (seconds):       0.279063 (Failed: 0; 0%)
- Output write time (seconds): 0.13423
+Total time (seconds):         8.62695
+Solver time (seconds):        8.52233
+ Assembly time (seconds):     5.81368 (Failed: 0; 0%)
+ Linear solve time (seconds): 2.20436 (Failed: 0; 0%)
+ Update time (seconds):       0.268837 (Failed: 0; 0%)
+ Output write time (seconds): 0.10786
 Overall Well Iterations:      35 (Failed: 0; 0%)
 Overall Linearizations:       99 (Failed: 0; 0%)
 Overall Newton Iterations:    67 (Failed: 0; 0%)


### PR DESCRIPTION
Reason: https://github.com/OPM/opm-simulators/pull/1471


libecl         = 7a97a61c1abcc221c1deaa98f2216dbe24f310c2
opm-common     = e864031bf43d802a70df3cb7be5e63edd23cb3a5
opm-grid       = 695eee592d29e2c9350a8fdb7b4e8fb6ef3a2cb1
opm-material   = f97f34ad5e96f88b1e3f019ec64a57e57dc75daa
ewoms          = 6ff575a3e65c570bdb7b65337fa8662865be9acc
opm-simulators = 7fe3358dbcd8542718186380e2346bc0f83de201