### PR TITLE
Update sp9 restart

### DIFF
--- a/spe9/SHORT.SCH
+++ b/spe9/SHORT.SCH
@@ -125,11 +125,18 @@ TSTEP
 -- At 100 days, the max oil rate for all producers is lowered
 -- to 100 STBO per D:
 WELTARG
-  'PRODU*' ORAT 100.0 /  
+  'PRODU*' ORAT 100.0 /
 /
 
 TSTEP
-6*10 /
+4*10 /
+
+DATES
+31 'MAY'  2015 /
+/
+
+TSTEP
+   10 /
 
 -- At 160 days, the max oil rate for all producers is changed
 -- back to 1500 STBO per D:

--- a/spe9/SPE9_CP_SHORT.UNRST
+++ b/spe9/SPE9_CP_SHORT.UNRST
@@ -1,0 +1,1 @@
+opm-simulation-reference/flow/SPE9_CP_SHORT.UNRST


### PR DESCRIPTION
This is a preparation step for: https://github.com/OPM/opm-common/issues/1396

As part of https://github.com/OPM/opm-common/issues/1396 there will be a stronger coupling between the input deck and the restart file - in the case of a restarted case the restart file can semantically be perceived as an include file.

The first commit makes sure that the date we are restarting from is explicitly mentioned in the Schedule section - this is *highly recommended* in the manual. The second commit makes the restart file available (as a symlink) from the location of the input file.