### PR TITLE
Remove DATE and performance related summary keywords

### DIFF
--- a/model2/include/summary.inc
+++ b/model2/include/summary.inc
@@ -9,20 +9,6 @@
 
 -- Summary file for the base case, specific version
 
-DATE
-
-NEWTON
-MLINEARS
-NLINEARS
-ELAPSED
-STEPTYPE
-TCPU
-TCPUDAY
-TIMESTEP
-TCPUTS
-WNEWTON
-
------------------
 -- Field Data
 -----------------
 -- Production rates


### PR DESCRIPTION
See this [comment](https://github.com/OPM/opm-common/pull/1656#issuecomment-607233604).

The performance related keywords are removed because they are not really suitable for regression testing - but we do not support them either.

The DATE keyword is removed because we do not support it.

So - since the keywords removed in this PR are not supported anyway I would say we could safely run a update data right away - on this particular PR. I will initiate the process and let others double check my logic and (hopefully) merge.

