### PR TITLE
Model2 prediction

### DIFF
--- a/model2/0A1_GRCTRL_LRAT_ORAT_BASE_MODEL2_MSW.DATA
+++ b/model2/0A1_GRCTRL_LRAT_ORAT_BASE_MODEL2_MSW.DATA
@@ -227,6 +227,7 @@ GRUPTREE
    'PROD'     'FIELD'  /
 /
 
+
 -- Well proportions
 GUIDERAT
 -- int phase A  B  C D E F incr. damp
@@ -240,15 +241,36 @@ GCONPROD
   'WGRP2' 'FLD'   900.  1*   1.E6  2400. 'RATE' 'YES' 1*  / 
 /
 
+WELSPECS
+-- Well   Grp	  I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD1  'WGRP1'   6  3  1*	  OIL	0.0	  STD	   STOP      YES    0	      SEG	0	     /
+    /
+
 INCLUDE
   'include/prod1_compl.inc' /
+
+WELSPECS
+--- Well   Grp       I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'WGRP2'   10  4   1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
 
 INCLUDE
   'include/prod2_compl.inc' /
 
+WELSPECS
+-- Well   Grp	     I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'WGRP1'   11  19  1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
+
 INCLUDE
   'include/prod3_compl.inc' /
 
+
+WELSPECS
+-- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ1  'INJE'	2  13  1*      WATER   0.0	 STD	  STOP      YES    0	     SEG       0	    /
+ /
+ 
 INCLUDE
   'include/inj1_compl.inc' /
 
@@ -271,6 +293,7 @@ WCONPROD
   'PROD2'  'OPEN'      'GRUP'    350000.      1*      1*      1*   1*    190. /
   'PROD3'  'OPEN'      'GRUP'    350000.      1*      1*      1*   1*    190. /
 /
+
 
 
 WEFAC

--- a/model2/0A1_GRCTRL_LRAT_ORAT_BASE_MODEL2_STW.DATA
+++ b/model2/0A1_GRCTRL_LRAT_ORAT_BASE_MODEL2_STW.DATA
@@ -235,14 +235,34 @@ GCONPROD
   'WGRP2' 'FLD'   900.  1*   1.E6  2400. 'RATE' 'YES' 1*  / 
 /
 
+WELSPECS
+-- Well   Grp	  I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD1  WGRP1   6  3  1*	  OIL	0.0	  STD	   STOP      YES    0	      SEG	0	     /
+    /
+
 INCLUDE
   'include/prod1_compl.inc' /
+
+WELSPECS
+--- Well   Grp       I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'WGRP2'   10  4   1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
 
 INCLUDE
   'include/prod2_compl.inc' /
 
+WELSPECS
+-- Well   Grp	     I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'WGRP1'   11  19  1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
+
 INCLUDE
   'include/prod3_compl.inc' /
+
+WELSPECS
+-- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ1  INJE	2  13  1*      WATER   0.0	 STD	  STOP      YES    0	     SEG       0	    /
+    /
 
 INCLUDE
   'include/inj1_compl.inc' /

--- a/model2/0A2_GRCTRL_LRAT_ORAT_GGR_BASE_MODEL2_MSW.DATA
+++ b/model2/0A2_GRCTRL_LRAT_ORAT_GGR_BASE_MODEL2_MSW.DATA
@@ -239,14 +239,34 @@ GCONPROD
   'WGRP2' 'FLD'   900.  1*   1.E6  2400. 'RATE' 'YES' 1*  'FORM'  7* /
 /
 
+WELSPECS
+-- Well   Grp	  I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD1  WGRP1   6  3  1*	  OIL	0.0	  STD	   STOP      YES    0	      SEG	0	     /
+    /
+
 INCLUDE
   'include/prod1_compl.inc' /
+
+WELSPECS
+--- Well   Grp       I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'WGRP2'   10  4   1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
 
 INCLUDE
   'include/prod2_compl.inc' /
 
+WELSPECS
+-- Well   Grp	     I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'WGRP1'   11  19  1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
+
 INCLUDE
   'include/prod3_compl.inc' /
+
+WELSPECS
+-- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ1  INJE	2  13  1*      WATER   0.0	 STD	  STOP      YES    0	     SEG       0	    /
+    /
 
 INCLUDE
   'include/inj1_compl.inc' /

--- a/model2/0A2_GRCTRL_LRAT_ORAT_GGR_BASE_MODEL2_STW.DATA
+++ b/model2/0A2_GRCTRL_LRAT_ORAT_GGR_BASE_MODEL2_STW.DATA
@@ -235,14 +235,34 @@ GCONPROD
   'WGRP2' 'FLD'   900.  1*   1.E6  2400. 'RATE' 'YES' 1*  'FORM'  7* /
 /
 
+WELSPECS
+-- Well   Grp	  I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD1  WGRP1   6  3  1*	  OIL	0.0	  STD	   STOP      YES    0	      SEG	0	     /
+    /
+
 INCLUDE
   'include/prod1_compl.inc' /
+
+WELSPECS
+--- Well   Grp       I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'WGRP2'   10  4   1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
 
 INCLUDE
   'include/prod2_compl.inc' /
 
+WELSPECS
+-- Well   Grp	     I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'WGRP1'   11  19  1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
+
 INCLUDE
   'include/prod3_compl.inc' /
+
+WELSPECS
+-- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ1  INJE	2  13  1*      WATER   0.0	 STD	  STOP      YES    0	     SEG       0	    /
+    /
 
 INCLUDE
   'include/inj1_compl.inc' /

--- a/model2/0A3_GRCTRL_LRAT_LRAT_BASE_MODEL2_MSW.DATA
+++ b/model2/0A3_GRCTRL_LRAT_LRAT_BASE_MODEL2_MSW.DATA
@@ -240,14 +240,34 @@ GCONPROD
   'WGRP2' 'FLD'   900.  1*   1.E6  2400. 'RATE' 'YES' 1*  / 
 /
 
+WELSPECS
+-- Well   Grp	  I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD1  WGRP1   6  3  1*	  OIL	0.0	  STD	   STOP      YES    0	      SEG	0	     /
+    /
+
 INCLUDE
   'include/prod1_compl.inc' /
+
+WELSPECS
+--- Well   Grp       I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'WGRP2'   10  4   1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
 
 INCLUDE
   'include/prod2_compl.inc' /
 
+WELSPECS
+-- Well   Grp	     I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'WGRP1'   11  19  1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
+
 INCLUDE
   'include/prod3_compl.inc' /
+
+WELSPECS
+-- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ1  INJE	2  13  1*      WATER   0.0	 STD	  STOP      YES    0	     SEG       0	    /
+    /
 
 INCLUDE
   'include/inj1_compl.inc' /

--- a/model2/0A3_GRCTRL_LRAT_LRAT_BASE_MODEL2_STW.DATA
+++ b/model2/0A3_GRCTRL_LRAT_LRAT_BASE_MODEL2_STW.DATA
@@ -236,14 +236,34 @@ GCONPROD
   'WGRP2' 'FLD'   900.  1*   1.E6  2400. 'RATE' 'YES' 1*  / 
 /
 
+WELSPECS
+-- Well   Grp	  I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD1  WGRP1   6  3  1*	  OIL	0.0	  STD	   STOP      YES    0	      SEG	0	     /
+    /
+
 INCLUDE
   'include/prod1_compl.inc' /
+
+WELSPECS
+--- Well   Grp       I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'WGRP2'   10  4   1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
 
 INCLUDE
   'include/prod2_compl.inc' /
 
+WELSPECS
+-- Well   Grp	     I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'WGRP1'   11  19  1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
+
 INCLUDE
   'include/prod3_compl.inc' /
+
+WELSPECS
+-- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ1  INJE	2  13  1*      WATER   0.0	 STD	  STOP      YES    0	     SEG       0	    /
+    /
 
 INCLUDE
   'include/inj1_compl.inc' /

--- a/model2/0A4_GRCTRL_LRAT_LRAT_GGR_BASE_MODEL2_MSW.DATA
+++ b/model2/0A4_GRCTRL_LRAT_LRAT_GGR_BASE_MODEL2_MSW.DATA
@@ -240,14 +240,34 @@ GCONPROD
   'WGRP2' 'FLD'   900.  1*   1.E6  2400. 'RATE' 'YES' 1*  'FORM'  7* /
 /
 
+WELSPECS
+-- Well   Grp	  I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD1  WGRP1   6  3  1*	  OIL	0.0	  STD	   STOP      YES    0	      SEG	0	     /
+    /
+
 INCLUDE
   'include/prod1_compl.inc' /
+
+WELSPECS
+--- Well   Grp       I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'WGRP2'   10  4   1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
 
 INCLUDE
   'include/prod2_compl.inc' /
 
+WELSPECS
+-- Well   Grp	     I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'WGRP1'   11  19  1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
+
 INCLUDE
   'include/prod3_compl.inc' /
+
+WELSPECS
+-- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ1  INJE	2  13  1*      WATER   0.0	 STD	  STOP      YES    0	     SEG       0	    /
+    /
 
 INCLUDE
   'include/inj1_compl.inc' /

--- a/model2/0A4_GRCTRL_LRAT_LRAT_GGR_BASE_MODEL2_STW.DATA
+++ b/model2/0A4_GRCTRL_LRAT_LRAT_GGR_BASE_MODEL2_STW.DATA
@@ -235,14 +235,34 @@ GCONPROD
   'WGRP2' 'FLD'   900.  1*   1.E6  2400. 'RATE' 'YES' 1*  'FORM'  7* /
 /
 
+WELSPECS
+-- Well   Grp	  I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD1  WGRP1   6  3  1*	  OIL	0.0	  STD	   STOP      YES    0	      SEG	0	     /
+    /
+
 INCLUDE
   'include/prod1_compl.inc' /
+
+WELSPECS
+--- Well   Grp       I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'WGRP2'   10  4   1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
 
 INCLUDE
   'include/prod2_compl.inc' /
 
+WELSPECS
+-- Well   Grp	     I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'WGRP1'   11  19  1*        OIL   0.0       STD      STOP	 YES	0	  SEG	    0		 /
+    /
+
 INCLUDE
   'include/prod3_compl.inc' /
+
+WELSPECS
+-- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ1  INJE	2  13  1*      WATER   0.0	 STD	  STOP      YES    0	     SEG       0	    /
+    /
 
 INCLUDE
   'include/inj1_compl.inc' /

--- a/model2/9_1A_DEPL_MAX_RATE_MIN_BHP_MSW.DATA
+++ b/model2/9_1A_DEPL_MAX_RATE_MIN_BHP_MSW.DATA
@@ -1,0 +1,434 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Depleation case, wells (multi segment well model) controlled with maximum 
+-- rates and minimum bottom hole pressure. No Group controls
+
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+WSEGITER
+ 150  50  0.3  2.0 /
+ 
+  
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   	           FIELD
+--   	             |
+--   		    PROD
+--         +------+--+---+-------+    
+--         |      |	 |	 |    
+--      PROD1  PROD2   PROD3  PROD4  
+
+
+GRUPTREE
+   'PROD'     'FIELD' /
+/
+
+WELSPECS
+-- Well    Grp      I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  2*   / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  2*   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well     Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  'PROD'    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  2*   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+
+WELSPECS
+-- Well    Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo     Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  2*   / 
+/
+
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_1A_DEPL_MAX_RATE_MIN_BHP_STW.DATA
+++ b/model2/9_1A_DEPL_MAX_RATE_MIN_BHP_STW.DATA
@@ -1,0 +1,411 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Depleation case, wells (standard well model) controlled with maximum rates and 
+-- minimum bottom hole pressure. No Group controls
+-- Model set up with standard well model
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   	           FIELD
+--   	             |
+--   		    PROD
+--         +------+--+---+-------+    
+--         |      |	 |	 |    
+--      PROD1  PROD2   PROD3  PROD4  
+
+
+GRUPTREE
+   'PROD'     'FIELD' /
+/
+
+WELSPECS
+-- Well    Grp      I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  2*   / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  2*   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well     Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  'PROD'    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  2*   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+
+WELSPECS
+-- Well    Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo     Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  2*   / 
+/
+
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_1B_DEPL_MAX_RATE_MIN_THP_MSW.DATA
+++ b/model2/9_1B_DEPL_MAX_RATE_MIN_THP_MSW.DATA
@@ -1,0 +1,430 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Depleation case, wells (multi segment well model) controlled with maximum 
+-- rates and minimum tubing head pressure. No Group controls
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+WSEGITER
+ 150  50  0.3  2.0 /
+
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   	           FIELD
+--   	             |
+--   		    PROD
+--         +------+--+---+-------+    
+--         |      |	 |	 |    
+--      PROD1  PROD2   PROD3  PROD4  
+
+
+GRUPTREE
+   'PROD'     'FIELD' /
+/
+
+WELSPECS
+-- Well    Grp      I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well     Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  'PROD'    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+
+WELSPECS
+-- Well    Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo     Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_1B_DEPL_MAX_RATE_MIN_THP_STW.DATA
+++ b/model2/9_1B_DEPL_MAX_RATE_MIN_THP_STW.DATA
@@ -1,0 +1,411 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Depleation case, wells (standard well model) controlled with maximum rates and 
+-- minimum tubing head pressure. No Group controls
+-- Model set up with standard well model.
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   	           FIELD
+--   	             |
+--   		    PROD
+--         +------+--+---+-------+    
+--         |      |	 |	 |    
+--      PROD1  PROD2   PROD3  PROD4  
+
+
+GRUPTREE
+   'PROD'     'FIELD' /
+/
+
+WELSPECS
+-- Well    Grp      I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well     Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  'PROD'    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+
+WELSPECS
+-- Well    Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo     Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_2A_DEPL_GCONPROD_1L_MSW.DATA
+++ b/model2/9_2A_DEPL_GCONPROD_1L_MSW.DATA
@@ -1,0 +1,435 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Depleation case, set up with maximum rates and minimum tubing head pressure. 
+-- GCONPROD with constraints on one group level
+-- Model set up with multi segment wells.
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+WSEGITER
+ 150  50  0.3  2.0 /
+
+  
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   	           FIELD
+--   	             |
+--   		    PROD
+--         +------+--+---+-------+    
+--         |      |	 |	 |    
+--      PROD1  PROD2   PROD3  PROD4  
+
+
+GRUPTREE
+   'PROD'     'FIELD' /
+/
+
+GCONPROD
+ 'PROD'    ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+WELSPECS
+-- Well    Grp      I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well     Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  'PROD'    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+
+WELSPECS
+-- Well    Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo     Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_2A_DEPL_GCONPROD_1L_STW.DATA
+++ b/model2/9_2A_DEPL_GCONPROD_1L_STW.DATA
@@ -1,0 +1,414 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Depleation case, set up with maximum rates and minimum tubing head pressure. 
+-- GCONPROD with constraints on one group level
+-- Model set up with standard well model.
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   	           FIELD
+--   	             |
+--   		    PROD
+--         +------+--+---+-------+    
+--         |      |	 |	 |    
+--      PROD1  PROD2   PROD3  PROD4  
+
+
+GRUPTREE
+   'PROD'     'FIELD' /
+/
+
+GCONPROD
+ 'PROD'    ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+WELSPECS
+-- Well    Grp      I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well     Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  'PROD'    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+
+WELSPECS
+-- Well    Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo     Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_2B_DEPL_GCONPROD_2L_MSW.DATA
+++ b/model2/9_2B_DEPL_GCONPROD_2L_MSW.DATA
@@ -1,0 +1,443 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Depleation case, set up with maximum rates and minimum tubing head pressure. 
+-- GCONPROD with constraints on one group level
+-- Model set up with multi segment wells.
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+WSEGITER
+ 150  50  0.3  2.0 /
+
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   			        |
+--   			      PROD
+--   		     ----------+------------
+--   		    |                      |	      
+--   		  MANI-A  	         MANI-B	   
+--   	     +-----+------+	    +-----+------+
+--   	     |     	  |         |	         |
+--   	  PROD1         PROD2	  PROD3	       PROD4
+
+
+GRUPTREE
+   'PROD'     'FIELD' /
+   'MANI-A'   'PROD'  /
+   'MANI-B'   'PROD'  /
+/
+
+GCONPROD
+ 'PROD'    ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+ 'MANI-A'  FLD    6000 12000 1.6E6  15000 RATE  'NO'  9* /
+ 'MANI-B'  FLD    6000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'MANI-B'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'MANI-A'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  MANI-A    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'MANI-B'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_2B_DEPL_GCONPROD_2L_STW.DATA
+++ b/model2/9_2B_DEPL_GCONPROD_2L_STW.DATA
@@ -1,0 +1,421 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Depleation case, set up with maximum rates and minimum tubing head pressure. 
+-- GCONPROD with constraints on one group level
+-- Model set up with standard well model.
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   			        |
+--   			      PROD
+--   		     ----------+------------
+--   		    |                      |	      
+--   		  MANI-A  	         MANI-B	   
+--   	     +-----+------+	    +-----+------+
+--   	     |     	  |         |	         |
+--   	  PROD1         PROD2	  PROD3	       PROD4
+
+
+GRUPTREE
+   'PROD'     'FIELD' /
+   'MANI-A'   'PROD'  /
+   'MANI-B'   'PROD'  /
+/
+
+GCONPROD
+ 'PROD'    ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+ 'MANI-A'  FLD    6000 12000 1.6E6  15000 RATE  'NO'  9* /
+ 'MANI-B'  FLD    6000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'MANI-B'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'MANI-A'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  MANI-A    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'MANI-B'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_3A_GINJ_REIN-G_MSW.DATA
+++ b/model2/9_3A_GINJ_REIN-G_MSW.DATA
@@ -1,0 +1,495 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Gas injection case. two gas injectors. GCONINJE with reinjection (100%) of
+-- produced gas. GCONPROD with constraints on one group level
+-- Model set up with multi segment well model.
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+WSEGITER
+ 150  50  0.3  2.0 /
+
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+INCLUDE
+ 'include/inj1_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     GAS   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+INCLUDE
+ 'include/inj2_msw_def.inc' /
+
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+INCLUDE
+ './include/inj1_reperf_msw_def.inc' /
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 2.1E6  15000 RATE  'NO'  9* /
+/
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_3A_GINJ_REIN-G_STW.DATA
+++ b/model2/9_3A_GINJ_REIN-G_STW.DATA
@@ -1,0 +1,463 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Gas injection case. two gas injectors. GCONINJE with reinjection (100%) of
+-- produced gas. GCONPROD with constraints on one group level
+-- Standard well model is used.
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     GAS   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 2.1E6  15000 RATE  'NO'  9* /
+/
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_3B_GINJ_GAS_EXPORT_MSW.DATA
+++ b/model2/9_3B_GINJ_GAS_EXPORT_MSW.DATA
@@ -1,0 +1,499 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Gas injection case. 100 % reinjection of produced gas from start of 
+-- simulation. Gas export (GCONSALE) and increased gas production capacity
+-- from 1st of June 1999.
+
+-- GCONPROD with constraints on one group level, and multi segment well model.
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+WSEGITER
+ 150  50  0.3  2.0 /
+
+
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+INCLUDE
+ 'include/inj1_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     GAS   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+INCLUDE
+ 'include/inj2_msw_def.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+INCLUDE
+ 'include/inj1_reperf_msw_def.inc' /
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 2.1E6  15000 RATE  'NO'  9* /
+/
+
+GCONSALE
+ 'RES' 0.75E6 0.80E6  0.5E6  RATE /
+/ 
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_3B_GINJ_GAS_EXPORT_STW.DATA
+++ b/model2/9_3B_GINJ_GAS_EXPORT_STW.DATA
@@ -1,0 +1,468 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Gas injection case. 100 % reinjection of produced gas from start of 
+-- simulation. Gas export (GCONSALE) and increased gas production capacity
+-- from 1st of June 1999.
+
+-- GCONPROD with constraints on one group level, and standard well model.
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     GAS   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 2.1E6  15000 RATE  'NO'  9* /
+/
+
+GCONSALE
+ 'RES' 0.75E6 0.80E6  0.5E6  RATE /
+/ 
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_3C_GINJ_GAS_GCONSUMP_MSW.DATA
+++ b/model2/9_3C_GINJ_GAS_GCONSUMP_MSW.DATA
@@ -1,0 +1,504 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Gas injection case. 100 % reinjection of produced gas and gas consumption
+-- of 0.25 MSm3 from start of simulation. Gas export (GCONSALE) and increased 
+-- gas production capacity from 1st of June 1999.
+
+-- GCONPROD with constraints on one group level, and multi segment well model.
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+WSEGITER
+ 150  50  0.3  2.0 /
+
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONSUMP
+ 'RES' 0.25E6 /
+/
+
+GCONINJE
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+INCLUDE
+ 'include/inj1_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     GAS   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+INCLUDE
+ 'include/inj2_msw_def.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+INCLUDE
+ 'include/inj1_reperf_msw_def.inc' /
+
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 2.1E6  15000 RATE  'NO'  9* /
+/
+
+GCONSALE
+ 'RES' 0.75E6 0.80E6  0.5E6  RATE /
+/ 
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_3C_GINJ_GAS_GCONSUMP_STW.DATA
+++ b/model2/9_3C_GINJ_GAS_GCONSUMP_STW.DATA
@@ -1,0 +1,474 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Gas injection case. 100 % reinjection of produced gas and gas consumption
+-- of 0.25 MSm3 from start of simulation. Gas export (GCONSALE) and increased 
+-- gas production capacity from 1st of June 1999.
+
+-- GCONPROD with constraints on one group level, and standard well model.
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONSUMP
+ 'RES' 0.25E6 /
+/
+
+GCONINJE
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     GAS   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   GAS   'OPEN'    'RATE'     2.0E6    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 2.1E6  15000 RATE  'NO'  9* /
+/
+
+GCONSALE
+ 'RES' 0.75E6 0.80E6  0.5E6  RATE /
+/ 
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_4A_WINJ_MAXWRATES_MAXBHP_GCONPROD_1L_MSW.DATA
+++ b/model2/9_4A_WINJ_MAXWRATES_MAXBHP_GCONPROD_1L_MSW.DATA
@@ -1,0 +1,489 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Water injection case. Two water injection wells set up with maximum rates  
+-- and maximum bottom hole pressure. No gas injection.
+-- Group control (GCONPROD) on production wells with constraints on 
+-- one group level. Model set up with multi segment well model. 
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+WSEGITER
+ 150  50  0.3  2.0 /
+
+
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      WATER   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+WELSEGS
+-- Name     Dep 1          Tlen 1      Vol 1     Len&Dep     PresDrop
+   INJ1     2533.59374     0.00000     1*        INC         'HF-'    /
+-- First Seg     Last Seg     Branch Num     Outlet Seg     Length      Depth Change     Diam        Rough    
+-- Main Stem Segments
+   2             2            1              1              4.23244     4.23114          0.15200     0.0000100 /
+   3             3            1              2              9.22711     9.22429          0.15200     0.0000100 /
+   4             4            1              3              9.98936     9.98630          0.15200     0.0000100 /
+   5             5            1              4              9.98939     9.98633          0.15200     0.0000100 /
+   6             6            1              5              6.24336     6.24145          0.15200     0.0000100 /
+   7             7            1              6              6.24330     6.24139          0.15200     0.0000100 /
+   8             8            1              7              9.98933     9.98627          0.15200     0.0000100 /
+   9             9            1              8              9.98932     9.98626          0.15200     0.0000100 /
+   10            10           1              9              9.98938     9.98632          0.15200     0.0000100 /
+   11            11           1              10             9.98939     9.98633          0.15200     0.0000100 /
+   12            12           1              11             9.52742     9.52451          0.15200     0.0000100 /
+    /
+
+INCLUDE
+  'include/inj1_reperf_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   WATER   'OPEN'    'RATE'   8000.0    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     WATER   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+INCLUDE
+ 'include/inj2_msw_def.inc' /
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   WATER   'OPEN'    'RATE'     8000.0    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_4A_WINJ_MAXWRATES_MAXBHP_GCONPROD_1L_STW.DATA
+++ b/model2/9_4A_WINJ_MAXWRATES_MAXBHP_GCONPROD_1L_STW.DATA
@@ -1,0 +1,448 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Water injection case. Two water injection wells set up with maximum rates  
+-- and maximum bottom hole pressure. No gas injection.
+-- Group control (GCONPROD) on production wells with constraints on 
+-- one group level. Model set up with standard well model. 
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      WATER   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   WATER   'OPEN'    'RATE'   8000.0    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     WATER   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   WATER   'OPEN'    'RATE'     8000.0    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_4B_WINJ_VREP-W_MSW.DATA
+++ b/model2/9_4B_WINJ_VREP-W_MSW.DATA
@@ -1,0 +1,496 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Water injection case. Two water injection wells set up with maximum rates  
+-- and maximum bottom hole pressure. No gas injection.
+-- Group control (GCONPROD) on production wells with constraints on 
+-- one group level. Group control on water injectors with 100% volume replacement, 
+-- VREP. Model set up with multi segment well model. 
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+WSEGITER
+ 150  50  0.3  2.0 /
+
+
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'WATER'  'VREP'  3*   1.0  /
+/ 
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      WATER   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+WELSEGS
+-- Name     Dep 1          Tlen 1      Vol 1     Len&Dep     PresDrop
+   INJ1     2533.59374     0.00000     1*        INC         'HF-'    /
+-- First Seg     Last Seg     Branch Num     Outlet Seg     Length      Depth Change     Diam        Rough    
+-- Main Stem Segments
+   2             2            1              1              4.23244     4.23114          0.15200     0.0000100 /
+   3             3            1              2              9.22711     9.22429          0.15200     0.0000100 /
+   4             4            1              3              9.98936     9.98630          0.15200     0.0000100 /
+   5             5            1              4              9.98939     9.98633          0.15200     0.0000100 /
+   6             6            1              5              6.24336     6.24145          0.15200     0.0000100 /
+   7             7            1              6              6.24330     6.24139          0.15200     0.0000100 /
+   8             8            1              7              9.98933     9.98627          0.15200     0.0000100 /
+   9             9            1              8              9.98932     9.98626          0.15200     0.0000100 /
+   10            10           1              9              9.98938     9.98632          0.15200     0.0000100 /
+   11            11           1              10             9.98939     9.98633          0.15200     0.0000100 /
+   12            12           1              11             9.52742     9.52451          0.15200     0.0000100 /
+    /
+
+INCLUDE
+  'include/inj1_reperf_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   WATER   'OPEN'    'RATE'   8000.0    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     WATER   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+INCLUDE
+ 'include/inj2_msw_def.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   WATER   'OPEN'    'RATE'     8000.0    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_4B_WINJ_VREP-W_STW.DATA
+++ b/model2/9_4B_WINJ_VREP-W_STW.DATA
@@ -1,0 +1,452 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Water injection case. Two water injection wells set up with maximum rates  
+-- and maximum bottom hole pressure. No gas injection.
+-- Group control (GCONPROD) on production wells with constraints on 
+-- one group level. Group control on water injectors with 100% volume replacement, 
+-- VREP. Model set up with standard well model. 
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'WATER'  'VREP'  3*   1.0  /
+/ 
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      WATER   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   WATER   'OPEN'    'RATE'   8000.0    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     WATER   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   WATER   'OPEN'    'RATE'     8000.0    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_4C_WINJ_GINJ_VREP-W_REIN-G_MSW.DATA
+++ b/model2/9_4C_WINJ_GINJ_VREP-W_REIN-G_MSW.DATA
@@ -1,0 +1,490 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Water and gas injection case. Two injectors (one water and one gas) set up with 
+-- maximum rates and maximum bottom hole pressure. 
+-- Group control (GCONPROD) on production wells with constraints on 
+-- one group level. Group control on water injectors with 125% volume replacement, and
+-- 100% re-injection of gas. Model set up with multi segment well model. 
+
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+WSEGITER
+ 150  50  0.3  2.0 /
+
+
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'WATER'  'VREP'  3*   1.25  /
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+INCLUDE
+ 'include/inj1_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'      1.6E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     WATER   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+INCLUDE
+ 'include/inj2_msw_def.inc' /
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   WATER   'OPEN'    'RATE'     8000.0    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+INCLUDE
+ 'include/inj1_reperf_msw_def.inc' /
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_4C_WINJ_GINJ_VREP-W_REIN-G_STW.DATA
+++ b/model2/9_4C_WINJ_GINJ_VREP-W_REIN-G_STW.DATA
@@ -1,0 +1,463 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Water and gas injection case. Two injectors (one water and one gas) set up with 
+-- maximum rates and maximum bottom hole pressure. 
+-- Group control (GCONPROD) on production wells with constraints on 
+-- one group level. Group control on water injectors with 125% volume replacement, and
+-- 100% re-injection of gas. Model set up with standard well model. 
+
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'WATER'  'VREP'  3*   1.25  /
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'      1.6E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     WATER   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   WATER   'OPEN'    'RATE'     8000.0    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_4D_WINJ_GINJ_GAS_EXPORT_MSW.DATA
+++ b/model2/9_4D_WINJ_GINJ_GAS_EXPORT_MSW.DATA
@@ -1,0 +1,508 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Water and gas injection case. Two injectors (one water and one gas) set up with 
+-- maximum rates and maximum bottom hole pressure. 
+-- Group control (GCONPROD) on production wells with constraints on 
+-- one group level. Group control on water injectors with 125% volume replacement, and
+-- 100% re-injection of gas. Increased gas production capacity and gass export from 
+-- 1st of June 2019. Model set up with multi segment well model. 
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+WSEGITER
+ 150  50  0.3  2.0 /
+
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'WATER'  'VREP'  3*   1.25  /
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+INCLUDE
+ 'include/inj1_msw_def.inc' /
+
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'      1.6E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     WATER   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+INCLUDE
+ 'include/inj2_msw_def.inc' /
+
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   WATER   'OPEN'    'RATE'     8000.0    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+INCLUDE
+ 'include/inj1_reperf_msw_def.inc' /
+
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 2.1E6  15000 RATE  'NO'  9* /
+/
+
+GCONSALE
+ 'RES' 0.75E6 0.80E6  0.5E6  RATE /
+/ 
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_4D_WINJ_GINJ_GAS_EXPORT_STW.DATA
+++ b/model2/9_4D_WINJ_GINJ_GAS_EXPORT_STW.DATA
@@ -1,0 +1,474 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Water and gas injection case. Two injectors (one water and one gas) set up with 
+-- maximum rates and maximum bottom hole pressure. 
+-- Group control (GCONPROD) on production wells with constraints on 
+-- one group level. Group control on water injectors with 125% volume replacement, and
+-- 100% re-injection of gas. Increased gas production capacity and gass export from 
+-- 1st of June 2019. Model set up with standard well model. 
+
+
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'WATER'  'VREP'  3*   1.25  /
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'      1.6E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     WATER   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   WATER   'OPEN'    'RATE'     8000.0    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 2.1E6  15000 RATE  'NO'  9* /
+/
+
+GCONSALE
+ 'RES' 0.75E6 0.80E6  0.5E6  RATE /
+/ 
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_4E_WINJ_GINJ_GUIDERATE_MSW.DATA
+++ b/model2/9_4E_WINJ_GINJ_GUIDERATE_MSW.DATA
@@ -1,0 +1,505 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Water and gas injection case. Two injectors (one water and one gas) set up with 
+-- maximum rates and maximum bottom hole pressure. 
+-- Group control (GCONPROD) on production wells with constraints on 
+-- one group level. Group control on water injectors with 125% volume replacement, and
+-- 100% re-injection of gas. Increased gas production capacity and gass export from 
+-- 1st of June 2019. Model set up with multi segment well model and keyword 
+-- GUIDRATE is used to prioritize wells with low GOR
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+
+WSEGDIMS
+-- nswlmx  nsegmx  nlbrmx
+  10       20     1 /
+
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+WSEGITER
+ 150  50  0.3  2.0 /
+
+
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'WATER'  'VREP'  3*   1.25  /
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+GUIDERAT
+ 30.0  'OIL'  1.0 1.0 0.0 0.0 1.0  1.25  1*  0.5 /  
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+INCLUDE
+ 'include/prod3_msw_def.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+INCLUDE
+ 'include/inj1_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'      1.6E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+INCLUDE
+ 'include/prod2_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+INCLUDE
+ 'include/prod1_msw_def.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     WATER   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+INCLUDE
+ 'include/inj2_msw_def.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   WATER   'OPEN'    'RATE'     8000.0    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+INCLUDE
+ 'include/inj1_reperf_msw_def.inc' /
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+INCLUDE
+ 'include/prod4_msw_def.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 2.1E6  15000 RATE  'NO'  9* /
+/
+
+GCONSALE
+ 'RES' 0.75E6 0.80E6  0.5E6  RATE /
+/ 
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/9_4E_WINJ_GINJ_GUIDERATE_STW.DATA
+++ b/model2/9_4E_WINJ_GINJ_GUIDERATE_STW.DATA
@@ -1,0 +1,474 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- ------------------------------------------------------------------------
+-- Prediction case based on model2/9_EDITNNC_MODEL2.DATA
+-- ------------------------------------------------------------------------
+
+-- Water and gas injection case. Two injectors (one water and one gas) set up with 
+-- maximum rates and maximum bottom hole pressure. 
+-- Group control (GCONPROD) on production wells with constraints on 
+-- one group level. Group control on water injectors with 125% volume replacement, and
+-- 100% re-injection of gas. Increased gas production capacity and gass export from 
+-- 1st of June 2019. Model set up with standard well model and keyword 
+-- GUIDRATE is used to prioritize wells with low GOR
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 / 
+
+SATOPTS
+ HYSTER  /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /   
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+ 
+
+MULTREGT 
+ 1  2	 0.0  2* F / 
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+ 
+------------------------------------------------------------------------------------------------  
+EDIT
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/fault_trans_xy.inc' /
+
+MULTIPLY
+ 'TRANZ'   0.05  1  13  1  22  8  8  /
+/
+
+INCLUDE
+ 'include/fault_editnnc.inc' /
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+ 
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+ 
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /  
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /   
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+ 
+RPTRST
+ 'BASIC=2' /
+  
+
+INCLUDE
+ 'include/D-1.Ecl' / 
+
+
+--   			      FIELD
+--   				|
+--   			       RES
+--   		     -----------+-------------------
+--   		    |			           |	      
+--   		  PROD  		         INJE     
+--   	     +-----+------+------+            +----+----+ 
+--   	     |     |	  |	 |            |	        |  
+--   	  PROD1  PROD2  PROD3  PROD4        INJ1      INJ2
+
+
+GRUPTREE
+   'RES'     'FIELD'  /
+   'INJE'     'RES'  /
+   'PROD'     'RES'  /
+/
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 1.6E6  15000 RATE  'NO'  9* /
+/
+
+GCONINJE
+ 'RES'      'WATER'  'VREP'  3*   1.25  /
+ 'RES'      'GAS'    'REIN'  2*   1.0  /
+/ 
+
+GUIDERAT
+ 30.0  'OIL'  1.0 1.0 0.0 0.0 1.0  1.25  1*  0.5 /  
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD3  'PROD'   11  19      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod3_compl.inc' /
+
+
+WELSPECS
+-- Well  Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'INJ1'  INJE	2  13     1*      GAS   0.0	 STD	  SHUT      YES    0	     SEG       0	    /
+ /
+
+INCLUDE
+ './include/inj1_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD3'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+WCONINJE
+-- WellN  Type  Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ1'   GAS   'OPEN'    'RATE'      1.6E6    1*      500.0   2*     / 
+/
+
+ 
+DATES   -- 2
+ 1 'DEC' 2018 /
+/
+
+
+WELSPECS
+-- Well    Grp     I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD2  'PROD'   10  4     1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod2_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD2'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 3
+ 2 'DEC' 2018 /
+/
+
+DATES   -- 6
+ 1 'JAN' 2019 /
+/
+
+WELSPECS
+-- Well    Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+  'PROD1'  PROD    6  3      1*     OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/prod1_compl.inc' /
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD1'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 7
+ 1 'FEB' 2019 /
+/
+
+WELSPECS
+-- Well   Grp    I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   INJ2  'INJE' 12  20      1*     WATER   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+INCLUDE
+ './include/inj2_compl.inc' /
+
+
+WCONINJE
+-- WellN  Type    Status  CtrlMode   SurfRate  ResVol   bhp    thp  VfpTab 
+ 'INJ2'   WATER   'OPEN'    'RATE'     8000.0    1*      500.0   2*     / 
+/
+
+DATES   -- 7
+ 1 'MAR' 2019 /
+/
+
+
+WELOPEN
+ 'INJ1' 'SHUT' 0 0 0 /
+/
+
+INCLUDE
+ './include/inj1_re_compl.inc' /
+
+DATES   -- 10
+ 1 'APR' 2019 /
+/
+
+WELSPECS
+-- Well   Grp       I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   PROD4  'PROD'    11  6      1*      OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+/
+
+
+INCLUDE
+ './include/prod4_compl.inc' /
+
+
+WCONPROD
+-- WellN  Status  CtrlMode  Qo    Qw     Qg     Qliq    Qresv   bhp   thp  VfpTab 
+ 'PROD4'  'OPEN'  'GRUP'  4000.0    1*  4.0E6    8000.0    1*    60.0  30.0   5   / 
+/
+
+
+DATES   -- 11
+ 1 'MAY' 2019 /
+/
+
+
+
+DATES   -- 11
+ 1 'JUN' 2019 /
+/
+
+
+GCONPROD
+ 'RES'   ORAT  10000 12000 2.1E6  15000 RATE  'NO'  9* /
+/
+
+GCONSALE
+ 'RES' 0.75E6 0.80E6  0.5E6  RATE /
+/ 
+
+
+
+DATES   -- 11
+ 1 'OCT' 2019 /
+/
+
+ 
+END

--- a/model2/include/inj1_compl.inc
+++ b/model2/include/inj1_compl.inc
@@ -7,10 +7,10 @@
 
 -- This file is one of the include files for model2
 
-WELSPECS
--- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
-   INJ1  INJE   2  13  1*      WATER   0.0       STD      STOP      YES    0         SEG       0            /
-    /
+--WELSPECS
+---- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+--   INJ1  INJE   2  13  1*      WATER   0.0       STD      STOP      YES    0         SEG       0            /
+--    /
     
 COMPDAT
 -- Well   I   J    K1   K2   Status   SAT   TR            DIAM      KH   S         Df   DIR

--- a/model2/include/inj1_re_compl.inc
+++ b/model2/include/inj1_re_compl.inc
@@ -7,10 +7,11 @@
 
 -- This file is one of the include files for model2
 
-WELSPECS
--- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
-   INJ1  1*   2  13  1*        OIL   0.0       STD      STOP      YES    0         SEG       0            /
-    /
+--WELSPECS
+---- Well  Grp  I  J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+--   INJ1  1*   2  13  1*        OIL   0.0       STD      STOP      YES    0         SEG       0            /
+--    /
+
 COMPDAT
 -- Well   I   J    K1   K2   Status   SAT   TR            DIAM      KH   S         Df   DIR
 -- ---- Completions for completion type Perforation ----

--- a/model2/include/inj2_compl.inc
+++ b/model2/include/inj2_compl.inc
@@ -1,0 +1,25 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- This file is one of the include files for model2
+
+
+--WELSPECS
+---- Well  Grp  I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+--   INJ2  1*   12  20  1*        OIL   0.0       STD      STOP      YES    0         SEG       0            /
+--    /
+
+COMPDAT
+-- Well   I    J    K1   K2   Status   SAT   TR            DIAM      KH   S         Df   DIR
+-- ---- Completions for completion type Perforation ----
+-- Perforation Completion : MD In: 69.1349 - MD Out: 78.5404 Transmissibility: 130.856
+   INJ2   12   20   9    9    OPEN     1*    1.308560E+2   0.21600   1*   0.00000   1*   'Z' /
+-- Perforation Completion : MD In: 78.5404 - MD Out: 88.5324 Transmissibility: 19.4049
+   INJ2   12   20   10   10   OPEN     1*    1.940490E+1   0.21600   1*   0.00000   1*   'Z' /
+-- Perforation Completion : MD In: 88.5324 - MD Out: 97.5105 Transmissibility: 69.1825
+   INJ2   12   20   11   11   OPEN     1*    6.918248E+1   0.21600   1*   0.00000   1*   'Z' /
+    /

--- a/model2/include/inj2_msw_def.inc
+++ b/model2/include/inj2_msw_def.inc
@@ -1,0 +1,34 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- This file is one of the include files for model2
+
+WELSEGS
+-- Name     Dep 1          Tlen 1      Vol 1     Len&Dep     PresDrop
+   INJ2     2593.13677     0.00000     1*        INC         'HF-'    /
+-- First Seg     Last Seg     Branch Num     Outlet Seg     Length      Depth Change     Diam        Rough    
+-- Main Stem Segments
+   2             2            1              1              3.04940     3.04930          0.15200     0.0000100 /
+   3             3            1              2              8.04535     8.04507          0.15200     0.0000100 /
+   4             4            1              3              9.99195     9.99161          0.15200     0.0000100 /
+   5             5            1              4              9.99198     9.99164          0.15200     0.0000100 /
+   6             6            1              5              6.24496     6.24474          0.15200     0.0000100 /
+   7             7            1              6              6.24492     6.24471          0.15200     0.0000100 /
+   8             8            1              7              9.99198     9.99164          0.15200     0.0000100 /
+   9             9            1              8              9.99201     9.99167          0.15200     0.0000100 /
+   10            10           1              9              9.99192     9.99158          0.15200     0.0000100 /
+   11            11           1              10             9.99192     9.99158          0.15200     0.0000100 /
+   12            12           1              11             9.48501     9.48468          0.15200     0.0000100 /
+    /
+COMPSEGS
+-- Name
+   INJ2 /
+-- I      J      K      Branch no     Start Length     End Length     Dir Pen     End Range     Connection Depth
+   12     20     9      1             69.13491         78.54044        /
+   12     20     10     1             78.54044         88.53239        /
+   12     20     11     1             88.53239         97.51045        /
+    /

--- a/model2/include/prod1_compl.inc
+++ b/model2/include/prod1_compl.inc
@@ -7,10 +7,11 @@
 
 -- This file is one of the include files for model2
 
-WELSPECS
--- Well   Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
-   PROD1  WGRP1   6  3  1*        OIL   0.0       STD      STOP      YES    0         SEG       0            /
-    /
+--WELSPECS
+---- Well   Grp     I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+--   PROD1  WGRP1   6  3  1*        OIL   0.0       STD      STOP      YES    0         SEG       0            /
+--    /
+
 COMPDAT
 -- Well    I   J   K1   K2   Status   SAT   TR            DIAM      KH   S         Df   DIR
 -- ---- Completions for completion type Perforation ----

--- a/model2/include/prod2_compl.inc
+++ b/model2/include/prod2_compl.inc
@@ -7,10 +7,11 @@
 
 -- This file is one of the include files for model2
 
-WELSPECS
--- Well   Grp       I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
-   PROD2  'WGRP2'   10  4   1*        OIL   0.0       STD      STOP      YES    0         SEG       0            /
-    /
+--WELSPECS
+----- Well   Grp       I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+--   PROD2  'WGRP2'   10  4   1*        OIL   0.0       STD      STOP      YES    0         SEG       0            /
+--    /
+
 COMPDAT
 -- Well    I    J   K1   K2   Status   SAT   TR            DIAM      KH   S         Df   DIR
 -- ---- Completions for completion type Perforation ----

--- a/model2/include/prod3_compl.inc
+++ b/model2/include/prod3_compl.inc
@@ -7,10 +7,11 @@
 
 -- This file is one of the include files for model2
 
-WELSPECS
--- Well   Grp        I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
-   PROD3  'WGRP1'   11  19  1*        OIL   0.0       STD      STOP      YES    0         SEG       0            /
-    /
+--WELSPECS
+---- Well   Grp        I   J   RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+--   PROD3  'WGRP1'   11  19  1*        OIL   0.0       STD      STOP      YES    0         SEG       0            /
+--    /
+
 COMPDAT
 -- Well    I    J    K1   K2   Status   SAT   TR            DIAM      KH   S         Df   DIR
 -- ---- Completions for completion type Perforation ----

--- a/model2/include/prod4_compl.inc
+++ b/model2/include/prod4_compl.inc
@@ -1,0 +1,26 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- This file is one of the include files for model2
+
+--WELSPECS
+---- Well   Grp  I   J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+--   PROD4  1*   11  6  1*        OIL   0.0       STD      STOP      YES    0         SEG       0            /
+--    /
+
+COMPDAT
+-- Well    I    J   K1   K2   Status   SAT   TR            DIAM      KH   S         Df   DIR
+-- ---- Completions for completion type Perforation ----
+-- Perforation Completion : MD In: 0 - MD Out: 8.3925 Transmissibility: 29.8535
+   PROD4   11   6   1    1    OPEN     1*    2.985345E+1   0.21600   1*   0.00000   1*   'Z' /
+-- Perforation Completion : MD In: 8.3925 - MD Out: 18.4021 Transmissibility: 0.659477
+   PROD4   11   6   2    2    OPEN     1*    6.594767E-1   0.21600   1*   0.00000   1*   'Z' /
+-- Perforation Completion : MD In: 18.4021 - MD Out: 28.4119 Transmissibility: 9.11594
+   PROD4   11   6   3    3    OPEN     1*    9.115936E+0   0.21600   1*   0.00000   1*   'Z' /
+-- Perforation Completion : MD In: 28.4119 - MD Out: 37.2758 Transmissibility: 41.4122
+   PROD4   11   6   4    4    OPEN     1*    4.141221E+1   0.21600   1*   0.00000   1*   'Z' /
+    /

--- a/model2/include/prod4_msw_def.inc
+++ b/model2/include/prod4_msw_def.inc
@@ -1,0 +1,28 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- This file is one of the include files for model2
+
+WELSEGS
+-- Name      Dep 1          Tlen 1      Vol 1     Len&Dep     PresDrop
+   PROD4     2573.46482     0.00000     1*        INC         'HF-'    /
+-- First Seg     Last Seg     Branch Num     Outlet Seg     Length       Depth Change     Diam        Rough    
+-- Main Stem Segments
+   2             2            1              1              4.19625      4.17540          0.15200     0.0000100 /
+   3             3            1              2              9.20107      9.15536          0.15200     0.0000100 /
+   4             4            1              3              10.00971     9.95999          0.15200     0.0000100 /
+   5             5            1              4              9.64411      9.59620          0.15200     0.0000100 /
+    /
+COMPSEGS
+-- Name 
+   PROD4 /
+-- I      J     K     Branch no     Start Length     End Length     Dir Pen     End Range     Connection Depth
+   11     6     1     1             0.00000          8.39250         /
+   11     6     2     1             8.39250          18.40214        /
+   11     6     3     1             18.40214         28.41193        /
+   11     6     4     1             28.41193         37.27578        /
+    /

--- a/model2/include/summary.inc
+++ b/model2/include/summary.inc
@@ -20,6 +20,8 @@ FLPR
 FOPRH
 FWPRH
 FGPRH
+FVPR
+FSGR
 -- Production cumulatives
 FOPT
 FWPT
@@ -35,7 +37,12 @@ FMCTP
 FMCTW
 FMCTG
 -- Injection rates
+FWIR
+FGIR
+FVIR
 -- Injection cumulatives
+FWIT
+FGIT
 -- Pressure and fluid
 -- In-place volumes
 -- Number of wells
@@ -128,6 +135,9 @@ WWIRH
 WBHP
  'PROD*' 'INJ*' /
 
+WTHP
+ 'PROD*'  /
+
 -- potentials 
 
 WGIP
@@ -176,7 +186,8 @@ GGPR
 /
 GLPR
 /
-
+GSGR
+/
 GMCTP
 /
 GMCTW

--- a/model2/include/summary.inc
+++ b/model2/include/summary.inc
@@ -20,8 +20,6 @@ FLPR
 FOPRH
 FWPRH
 FGPRH
-FVPR
-FSGR
 -- Production cumulatives
 FOPT
 FWPT
@@ -37,12 +35,7 @@ FMCTP
 FMCTW
 FMCTG
 -- Injection rates
-FWIR
-FGIR
-FVIR
 -- Injection cumulatives
-FWIT
-FGIT
 -- Pressure and fluid
 -- In-place volumes
 -- Number of wells
@@ -135,9 +128,6 @@ WWIRH
 WBHP
  'PROD*' 'INJ*' /
 
-WTHP
- 'PROD*'  /
-
 -- potentials 
 
 WGIP
@@ -186,8 +176,7 @@ GGPR
 /
 GLPR
 /
-GSGR
-/
+
 GMCTP
 /
 GMCTW


### PR DESCRIPTION
Adding prediction test cases for model2, based on model 9_EDITNNC_MODEL2.DATA. 

These cases are using the same include files for well completions and msw definitions as existing test cases 0A1-0A4, STW and MSW. 

Data decks for cases 0A1 to  0A4 is modified, but this is only cosmetic. WELSPECS keyword is moved from include file to the main deck file. 
