### PR TITLE
Adding one more test case which th PINCH ITEM4=ALL

### DIFF
--- a/pinch/PINCH_MULTZ_ALL_BARRIER.DATA
+++ b/pinch/PINCH_MULTZ_ALL_BARRIER.DATA
@@ -1,0 +1,270 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2020 Equinor
+
+-- test case is testing vertical communication set up with
+-- PINCH (item 5 = All) and MULTZ = 1.0
+-- In addition, adding EQUALS MULTZ=0.0 for layer number 10 which in this 
+-- model is pinched out (hence inactive). This shall genereate a barrier for 
+-- vertical flow when used together with PINCH item5 = All
+
+-- *****************************************************
+RUNSPEC
+-- *****************************************************
+
+-- Simulation run title
+TITLE
+Generic Reservoir
+
+NOECHO
+
+--
+-- ----------------------------------------------------
+-- Simulation grid dimension (Imax, Jmax, Kmax)
+DIMENS
+    1  1  19  /
+
+--
+-- ----------------------------------------------------
+-- Simulation run start
+START
+ 1 'JUL' 2018 /
+
+--
+-- ----------------------------------------------------
+--Activate "Data Check Only" option
+--NOSIM
+--
+--
+
+--
+-- ----------------------------------------------------
+-- Fluid phases present
+OIL
+GAS
+WATER
+DISGAS
+
+--
+-- ----------------------------------------------------
+-- Measurement unit used
+METRIC
+
+--
+--Table dimensions
+TABDIMS
+-- NTSFUN NTPVT NSSFUN NPPVT NTFIP NRPVT
+     1      1     130    24    1    20   /
+
+
+-- ----------------------------------------------------
+--Dimension for well data
+WELLDIMS
+ 3  25 3 3 /
+
+
+-- ----------------------------------------------------
+-- Input and output files format
+UNIFIN
+UNIFOUT
+
+
+
+-- *************************************************************************
+-- In this section simulation grid and static reservoir parameters are given
+-- *************************************************************************
+
+GRID 
+
+-- ****************************************************
+-------------------------------------------------------
+
+--
+--Disable echoing of the input file  
+NOECHO
+
+--
+--Requests output of an INIT file
+INIT
+
+--
+--Control output of the Grid geometry file
+GRIDFILE
+  0 1  /
+
+--Message print and stop limits
+MESSAGES
+ 3* 1000 4* 1000000 1000 /
+
+
+--
+-- ----------------------------------------------------
+--Include simulation grid
+INCLUDE
+  './include/test_1x1x19.grdecl' /
+
+MULTZ
+ 19*1.0 /
+
+
+
+
+EQUALS
+ 'PERMX' 10000 /
+ 'PERMY' 10000 /
+ 'PERMZ' 1000  /
+ 'NTG'   1.000 /
+ 'PORO'  0.25  /
+/
+
+PINCH
+     1*      'GAP'     1*  'TOPBOT'  'ALL'  / --default values
+
+EQUALS
+ 'MULTZ' 0.0 4* 10 10 /
+/
+ 
+
+-- ***************************************************
+-- In this section simulation grid parameters are edited
+-- ***************************************************
+
+EDIT
+
+-- ***************************************************
+
+
+-- ***************************************************
+-- In this section fluid-rock properties and 
+-- relative permabilities are given
+-- ***************************************************
+
+PROPS
+
+-- ***************************************************
+
+INCLUDE
+ './include/sgof.txt' /
+
+
+INCLUDE
+ './include/swof.txt' /
+
+-- ---------------------------------------------------
+
+-- Include PVT data
+INCLUDE
+  './include/example_pvt.txt' /
+
+-- ***********************************************************
+-- In this section simulation grid region parameters are given
+-- ***********************************************************
+
+REGIONS
+
+-- ***************************************************
+--
+-- ***************************************************
+-- In this section the initialization parameters aand
+-- dynamic parameters are defined
+-- ***************************************************
+
+EQUALS
+ 'EQLNUM' 1 /
+ 'SATNUM' 1 /
+/
+ 
+SOLUTION
+
+-- ***************************************************
+
+--
+--Simulation model initialisation data
+--
+--   DATUM  DATUM   OWC     OWC    GOC    GOC    RSVD   RVVD   SOLN
+--   Depth  Pres.   Depth   Pcow   Depth  Pcog   Table  Table  Method
+EQUIL
+     1900.0   225.0   1900.0  0.0    500    0.0     1     1      0 / 
+    
+
+--
+-- ---------------------------------------------------
+-- Dissolved gas-oil ratio versus depth, 
+
+RSVD
+
+ 1500 120.0
+ 4000 120.0  /
+ 
+
+RPTSOL
+  'THPRES' /
+
+
+RPTRST
+ 'BASIC=2'  'PBPD' /
+ 
+
+--
+-- **************************************************************************************
+-- In this section simulation output data to be written to summary file are defined
+-- **************************************************************************************
+
+SUMMARY
+
+-- ***************************************************
+-- ---------------------------------------------------
+-- Summary data to be written to summary file
+--
+-- Outputs the date to the summary file
+
+--
+--
+-- **************************************************************************************
+-- In this section data required to describe history and prediction is given
+-- - well completions, well production/injection, well constraints
+-- - platform/production unit constraints, etc.
+-- **************************************************************************************
+
+
+WBHP
+ P1 /
+
+WOPR
+ P1 /
+
+BPR
+ 1    1   1 /
+ 1    1   2 /
+ 1    1   18 /
+ 1    1   19 /
+/ 
+
+SCHEDULE
+
+-- ***************************************************
+
+WELSPECS
+-- Well  Grp  I  J  RefDepth  Type  DrainRad  GasInEq  AutoShut  XFlow  FluidPVT  HydSDens  FluidInPlReg
+   P1    TEST   1    1  1*        OIL   0.0       STD      SHUT      YES    0         SEG       0            /
+ /
+
+COMPDAT
+-- Well   I    J   K1   K2   Status   SAT   TR          DIAM      KH    S        Df   DIR
+   P1     1    1   1    1    OPEN     1*    1*        0.21600     1*   0.00000   1*   'Z' /
+/
+
+WCONPROD
+  P1  OPEN  ORAT  25.0  4*  150.0  /
+/  
+
+TSTEP
+ 1 2 5 5 /
+
+
+END
+
+


### PR DESCRIPTION
 * introduces a vertical flow barriere with MULTZ=0.0 for a pinched grid cell

This case is equal to case PINCH_MULTZ_ALL except for the addition 

```
EQUALS
 'MULTZ' 0.0 4* 10 10 /
/
```

Layer 10 is collapsed (hence inactive), but when used together with PINCH (item5 ALL) this should act as a barrier for vertical flow.  Current version of Flow is not honoring this flow barrier

