### PR TITLE
Re-perf well, don't update ref depth

### DIFF
--- a/norne/INCLUDE/B1H_RE-PERF.SCH
+++ b/norne/INCLUDE/B1H_RE-PERF.SCH
@@ -1,0 +1,126 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2020 Equinor
+
+
+--  WARN: B-1H Layer Tofte 2.1 2002 (13-15) changed to (13-13), pinchout?
+--  WARN: B-1H Layer Tofte 2.1 2002 (13-15) changed to (13-13), pinchout?
+--      : B-1H Perforation Tofte 2.1 2002 Top:  3730.00 Bot:  3760.00 Diam: 0.22 Skin: 0.00
+--      : >> --Tofte 2.1 2002
+--      : B-1H Perforation Tofte 2.1 2002 Top:  3986.00 Bot:  4250.00 Diam: 0.22 Skin: 0.00
+--      : >> --Tofte 2.1 2002
+--  WARN: B-1H Perf interval 4065.999853 to 4066.076648 outside all cells, discarded
+--      : B-1H Connection 17 44 15 Perf. Len  19.57 ( 22.0%)
+--      : B-1H Connection 17 45 15 Perf. Len  10.43 ( 12.1%)
+--      : B-1H Connection 17 47 15 Perf. Len  23.79 ( 27.0%)
+--      : B-1H Connection 17 48 15 Perf. Len  56.21 ( 64.8%)
+--      : B-1H Connection 18 48 15 Perf. Len  30.25 ( 34.8%)
+--      : B-1H Connection 18 49 15 Perf. Len  30.98 ( 35.3%)
+--      : B-1H Connection 18 49 14 Perf. Len  58.10 ( 65.3%)
+--      : B-1H Connection 18 50 14 Perf. Len  64.58 ( 73.7%)
+
+
+WELSPECS 
+     'B-1H'   'MANI-B2'   14   34  1*       'OIL'  2*      'STOP'  4* /
+/
+
+COMPDAT 
+-- WELL        I    J    K1  K2            Sat.        CF       DIAM        KH SKIN ND        DIR   Ro 
+     'B-1H'   17   44   15   15      'OPEN'  1*     34.720      0.216   3095.832  2*         'Y'     12.828 /
+     'B-1H'   17   45   15   15      'OPEN'  1*     19.976      0.216   1779.033  2*         'Y'     12.754 /
+     'B-1H'   17   47   15   15      'OPEN'  1*     51.570      0.216   4598.853  2*         'Y'     12.835 /
+     'B-1H'   17   48   15   15      'OPEN'  1*    146.533      0.216  13073.180  2*         'Y'     12.863 /
+     'B-1H'   18   48   15   15      'OPEN'  1*     80.994      0.216   7382.913  2*         'Y'     14.269 /
+     'B-1H'   18   49   15   15      'OPEN'  1*    101.426      0.216   9266.828  2*         'Y'     14.432 /
+     'B-1H'   18   49   14   14      'OPEN'  1*    305.155      0.216  27750.031  2*         'Y'     14.105 /
+     'B-1H'   18   50   14   14      'OPEN'  1*    425.169      0.216  38596.840  2*         'Y'     13.986 /
+/
+
+WCONHIST 
+     'B-1H'      'OPEN'      'ORAT'      0.000      0.000      0.000  5* /
+/
+
+
+-- 507.000000 days from start of simulation ( 6 'NOV' 1997 )
+DATES
+ 28 'MAR' 1999 /
+/
+
+--      : B-1H Perforation Ile 1.2 2002 Top:  3350.00 Bot:  3426.00 Diam: 0.22 Skin: 0.00
+--      : >> --Ile 1.2 2002
+--      : B-1H Perforation Ile 1.2 2002 Top:  3474.00 Bot:  3514.00 Diam: 0.22 Skin: 0.00
+--      : >> --Ile 1.2 2002
+--      : B-1H Perforation Ile 1.3 2002 Top:  3200.00 Bot:  3209.50 Diam: 0.22 Skin: 0.00
+--      : >> --Ile 1.3 2002 (DIVIDED)
+--  WARN: B-1H Layer Ile 1.3 2002 Adjusted 3200.00 3209.50 to 3168.44 3177.94
+--      : B-1H Perforation Ile 1.2 2002 Top:  3209.50 Bot:  3320.00 Diam: 0.22 Skin: 0.00
+--      : >> --Ile 1.2 2002
+--  WARN: B-1H Perf interval 3317.734605 to 3317.810210 outside all cells, discarded
+--      : B-1H Perforation Ile 1.2 2002 Top:  3580.00 Bot:  3650.00 Diam: 0.22 Skin: 0.00
+--      : >> --Ile 1.2 2002
+--  WARN: B-1H Layer Ile 1.2 2002 Adjusted 3580.00 3650.00 to 3458.65 3528.65
+--      : B-1H Connection 15 38  9 Perf. Len   9.50 ( 10.4%)
+--      : B-1H Connection 16 38 10 Perf. Len  24.05 ( 26.4%)
+--      : B-1H Connection 16 39 10 Perf. Len  84.19 ( 97.3%)
+--      : B-1H Connection 16 40 10 Perf. Len  57.18 ( 63.8%)
+--      : B-1H Connection 16 41 10 Perf. Len  53.09 ( 60.9%)
+--      : B-1H Connection 16 42 10 Perf. Len  37.91 ( 43.7%)
+--      : B-1H Connection 17 44 15 Perf. Len  19.57 ( 22.0%)
+--      : B-1H Connection 17 45 15 Perf. Len  10.43 ( 12.1%)
+--      : B-1H Connection 17 47 15 Perf. Len  23.79 ( 27.0%)
+--      : B-1H Connection 17 48 15 Perf. Len  56.21 ( 64.8%)
+--      : B-1H Connection 18 48 15 Perf. Len  30.25 ( 34.8%)
+--      : B-1H Connection 18 49 15 Perf. Len  30.98 ( 35.3%)
+--      : B-1H Connection 18 49 14 Perf. Len  58.10 ( 65.3%)
+--      : B-1H Connection 18 50 14 Perf. Len  64.58 ( 73.7%)
+WELOPEN 
+     'B-1H'      'SHUT'    0    0    0  2* /
+/
+
+COMPDAT 
+-- WELL        I    J    K1  K2            Sat.        CF       DIAM        KH SKIN ND        DIR   Ro 
+     'B-1H'   15   38    9    9      'OPEN'  1*     25.620      0.216   2086.842  2*         'Y'      8.486 /
+     'B-1H'   16   38   10   10      'OPEN'  1*     65.351      0.216   5227.131  2*         'Y'      7.844 /
+     'B-1H'   16   39   10   10      'OPEN'  1*    206.584      0.216  15780.745  2*         'Y'      6.469 /
+     'B-1H'   16   40   10   10      'OPEN'  1*    139.254      0.216  10698.725  2*         'Y'      6.624 /
+     'B-1H'   16   41   10   10      'OPEN'  1*    134.824      0.216  10345.683  2*         'Y'      6.590 /
+     'B-1H'   16   42   10   10      'OPEN'  1*     99.806      0.216   7702.339  2*         'Y'      6.747 /
+     'B-1H'   17   44   15   15      'OPEN'  1*     34.720      0.216   3095.832  2*         'Y'     12.828 /
+     'B-1H'   17   45   15   15      'OPEN'  1*     19.976      0.216   1779.033  2*         'Y'     12.754 /
+     'B-1H'   17   47   15   15      'OPEN'  1*     51.570      0.216   4598.853  2*         'Y'     12.835 /
+     'B-1H'   17   48   15   15      'OPEN'  1*    146.533      0.216  13073.180  2*         'Y'     12.863 /
+     'B-1H'   18   48   15   15      'OPEN'  1*     80.994      0.216   7382.913  2*         'Y'     14.269 /
+     'B-1H'   18   49   15   15      'OPEN'  1*    101.426      0.216   9266.828  2*         'Y'     14.432 /
+     'B-1H'   18   49   14   14      'OPEN'  1*    305.155      0.216  27750.031  2*         'Y'     14.105 /
+     'B-1H'   18   50   14   14      'OPEN'  1*    425.169      0.216  38596.840  2*         'Y'     13.986 /
+/
+
+WCONHIST 
+     'B-1H'      'OPEN'      'ORAT'      0.000      0.000      0.000  5* /
+/
+
+
+-- 511.000000 days from start of simulation ( 6 'NOV' 1997 )
+DATES
+ 1 'APR' 1999 /
+/
+
+WCONHIST 
+     'B-1H'      'OPEN'      'RESV'   4334.313      0.000 832512.553  5* /
+/
+
+RPTSCHED 
+ 0 0 0 0 0 0 2 2 2 0 1 1 0 1 1 0 0 / 
+
+
+-- 541.000000 days from start of simulation ( 6 'NOV' 1997 )
+DATES
+ 4 'APR' 1999 /
+/
+
+
+END
+

--- a/norne/NORNE_ATW2013_B1H_RE-PERF.DATA
+++ b/norne/NORNE_ATW2013_B1H_RE-PERF.DATA
@@ -1,0 +1,655 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2020 Equinor
+
+-- Based on Norne full field model for SPE ATW 2013
+-- This model only include well B-1H which initially is perforated layer 14-15
+-- Then additional perforations are added layer 9 and 10. WELSPECS only defined
+-- once and item 5 is defaulted 
+--    => reference depth is then set to center depth of first connection (defined by compord).
+
+-- Well is then re-perforated (additional perforations). Connections are added with keyword COMPDAT
+-- The referece depth should now NOT be re-defined. 
+
+RUNSPEC
+
+DIMENS
+46 112 22   /
+
+--NOSIM
+
+GRIDOPTS
+ 'YES' 0 /
+
+OIL
+
+WATER
+
+GAS
+
+DISGAS
+
+VAPOIL
+
+ENDSCALE
+NODIR   REVERS /
+
+METRIC
+
+SATOPTS
+HYSTER  /
+
+START
+ 26  'MAR' 1999 /
+
+EQLDIMS
+ 5  100  20 /
+
+EQLOPTS
+ 'THPRES'  /   no fine equilibration if swatinit is being used
+
+REGDIMS
+-- ntfip  nmfipr  nrfreg  ntfreg
+    22      3      1*      20    /
+
+TRACERS
+--  oil  water  gas  env
+    1*   7      1*    1*   /
+ 
+WELLDIMS
+ 130  36  15  84 /
+
+TABDIMS
+--ntsfun ntpvt nssfun nppvt ntfip nrpvt ntendp
+   2     2     33     60   16    60 /
+
+-- WI_VFP_TABLES_080905.INC = 10-20
+VFPIDIMS
+ 30    20   20 /
+
+-- Table no.
+-- DevNew.VFP        = 1
+-- E1h.VFP           = 2
+-- AlmostVertNew.VFP = 3
+-- GasProd.VFP       = 4
+-- NEW_D2_GAS_0.00003.VFP = 5
+-- GAS_PD2.VFP = 6
+-- pd2.VFP           = 8 (flowline south)
+-- pe2.VFP           = 9 (flowline north)
+-- PB1.PIPE.Ecl  = 31
+-- PB2.PIPE.Ecl  = 32  
+-- PD1.PIPE.Ecl  = 33  
+-- PD2.PIPE.Ecl  = 34 
+-- PE1.PIPE.Ecl  = 35
+-- PE2.PIPE.Ecl  = 36
+-- B1BH.Ecl = 37
+-- B2H.Ecl  = 38
+-- B3H.Ecl  = 39
+-- B4DH. Ecl= 40
+-- D1CH.Ecl = 41
+-- D2H.Ecl  = 42
+-- D3BH.Ecl = 43
+
+-- E1H.Ecl  = 45 
+-- E3CH.Ecl = 47
+-- K3H.Ecl  = 48
+
+
+VFPPDIMS
+ 19  10  10  10  0  50 /
+
+FAULTDIM
+10000 /
+
+PIMTDIMS
+1  51 /
+
+NSTACK
+ 30 /
+
+UNIFIN
+UNIFOUT
+
+--FMTOUT
+--FMTIN
+
+OPTIONS
+77* 1 /
+
+---------------------------------------------------------
+--
+--	Input of grid geometry
+--
+---------------------------------------------------------
+GRID
+
+NEWTRAN
+
+-- Ask for an EGRID file; no .GRID output.
+GRIDFILE
+  0  1 /
+
+-- optional for postprocessing of GRID
+MAPAXES
+ 0.  100.  0.  0.  100.  0.  /
+
+GRIDUNIT
+METRES  /
+
+-- requests output of INIT file
+INIT
+
+MESSAGES
+ 8*10000  20000 10000 1000 1* /
+
+PINCH
+ 0.001 GAP  1* TOPBOT TOP/
+
+NOECHO
+
+--------------------------------------------------------
+--
+--  	Grid and faults
+--
+--------------------------------------------------------
+
+-- Simulation grid, with slooping faults:
+-- file in UTM coordinate system, for importing to DecisionSpace
+INCLUDE
+ './INCLUDE/GRID/IRAP_1005.GRDECL' / 
+
+--
+INCLUDE
+ './INCLUDE/GRID/ACTNUM_0704.prop' / 
+
+-- Faults
+INCLUDE
+ './INCLUDE/FAULT/FAULT_JUN_05.INC' / 
+
+-- Alteration of transmiscibility by use of the 'MULTFLT' keyword
+INCLUDE
+ './INCLUDE/FAULT/FAULTMULT_AUG-2006.INC' / 
+
+--------------------------------------------------------
+--
+--  	Input of grid parametres
+--
+--------------------------------------------------------
+
+--
+INCLUDE
+ './INCLUDE/PETRO/PORO_0704.prop' / 
+
+INCLUDE
+ './INCLUDE/PETRO/NTG_0704.prop' / 
+
+INCLUDE
+ './INCLUDE/PETRO/PERM_0704.prop' / 
+
+COPY
+   PERMX PERMY /
+   PERMX PERMZ /
+/
+
+-- based on same kv/kh factor
+MULTIPLY
+   'PERMZ' 0.2    1 46 1 112  1  1 /    Garn 3
+   'PERMZ' 0.04   1 46 1 112  2  2 /    Garn 2
+   'PERMZ' 0.25   1 46 1 112  3  3 /    Garn 1
+   'PERMZ' 0.0    1 46 1 112  4  4 /    Not 	(inactive anyway)
+   'PERMZ' 0.13   1 46 1 112  5  5 /    Ile 2.2
+   'PERMZ' 0.13   1 46 1 112  6  6 /    Ile 2.1.3
+   'PERMZ' 0.13   1 46 1 112  7  7 /    Ile 2.1.2
+   'PERMZ' 0.13   1 46 1 112  8  8 /    Ile 2.1.1
+   'PERMZ' 0.09   1 46 1 112  9  9 /    Ile 1.3
+   'PERMZ' 0.07   1 46 1 112 10 10 /    Ile 1.2
+   'PERMZ' 0.19   1 46 1 112 11 11 /    Ile 1.1
+   'PERMZ' 0.13   1 46 1 112 12 12 /    Tofte 2.2
+   'PERMZ' 0.64   1 46 1 112 13 13 /	Tofte 2.1.3
+   'PERMZ' 0.64   1 46 1 112 14 14 /	Tofte 2.1.2
+   'PERMZ' 0.64   1 46 1 112 15 15 /	Tofte 2.1.1
+   'PERMZ' 0.64   1 46 1 112 16 16 /	Tofte 1.2.2
+   'PERMZ' 0.64   1 46 1 112 17 17 /	Tofte 1.2.1
+   'PERMZ' 0.016  1 46 1 112 18 18 /	Tofte 1.1
+   'PERMZ' 0.004  1 46 1 112 19 19 /	Tilje 4
+   'PERMZ' 0.004  1 46 1 112 20 20 /	Tilje 3
+   'PERMZ' 1.0    1 46 1 112 21 21 /	Tilje 2
+   'PERMZ' 1.0    1 46 1 112 22 22 /	Tilje 1
+/
+
+
+--------------------------------------------------------
+--
+--      Barriers
+--
+--------------------------------------------------------
+
+-- MULTZ multiplies the transmissibility between blocks
+-- (I, J, K) and (I, J, K+1), thus the barriers are at the
+-- bottom of the given layer.
+
+-- Region barriers
+INCLUDE
+ './INCLUDE/PETRO/MULTZ_HM_1.INC' / 
+
+-- Field-wide barriers
+EQUALS
+  'MULTZ'    1.0      1  46  1 112   1   1  / Garn3       - Garn 2
+  'MULTZ'    0.05     1  46  1 112  15  15  / Tofte 2.1.1 - Tofte 1.2.2
+  'MULTZ'    0.001    1  46  1 112  18  18  / Tofte 1.1   - Tilje 4
+  'MULTZ'    0.00001  1  46  1 112  20  20  / Tilje 3     - Tilje 2
+-- The Top Tilje 2 barrier is included as MULTREGT = 0.0
+/
+
+-- Local barriers
+INCLUDE
+ './INCLUDE/PETRO/MULTZ_JUN_05_MOD.INC' / 
+  
+  
+-- 20 flux regions generated by the script Xfluxnum
+INCLUDE
+ './INCLUDE/PETRO/FLUXNUM_0704.prop' / 
+
+-- modify transmissibilites between fluxnum using MULTREGT
+INCLUDE
+ './INCLUDE/PETRO/MULTREGT_D_27.prop' / 
+
+NOECHO
+
+MINPV
+  500 /
+
+EDIT
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+  
+PROPS
+--------------------------------------------------------------------------------
+--
+--    Input of fluid properties and relative permeability
+--
+---------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+'./INCLUDE/PVT/PVT-WET-GAS.INC' / 
+
+TRACER
+SEA  WAT  /
+HTO  WAT  /
+S36  WAT  /
+2FB  WAT  /
+4FB  WAT  /
+DFB  WAT  /
+TFB  WAT  /
+/
+
+-- initial water saturation
+INCLUDE
+'./INCLUDE/PETRO/SWINITIAL.INC' /
+
+-- relative perm.
+INCLUDE
+'./INCLUDE/RELPERM/SCAL_NORNE.INC' /
+
+SCALECRS
+YES /
+
+-- endpoints may be used as tuning papameters
+EQUALS
+SWL 0.04 1 46 1 112 1  1   / 
+SWL 0.05 1 46 1 112 2  2   / 
+SWL 0.15 1 46 1 112 3  3   / 
+SWL 0.15 1 46 1 112 4  4   / 
+SWL 0.05 1 46 1 112 5  10  / Ile 2.2.2 and Ile 2.2.1, Ile 2.1.3, Ile 2.1.2, and Ile 2.1.1 Ile 1.3 and Ile 1.2
+SWL 0.16 1 46 1 112 11 12  / ile 1.1 and tofte 2.2
+SWL 0.07 1 46 1 112 13 15  / tofte 2.1
+SWL 0.06 1 46 1 112 16 16  / tofte 1.2.2
+SWL 0.12 1 46 1 112 17 22  / Tofte 1.2.1, Tofte 1.2.1, tofte 1.1, tilje 
+/
+
+COPY
+  SWL SWCR /
+  SWL SGU  /
+/
+
+
+ADD
+SWCR   0.08  1 46 1 112 1 22  /
+/
+
+-- SGU = 1 - SWL
+MULTIPLY
+SGU  -1  1 46 1 112 1 22  /
+/
+
+ADD
+SGU   1  1 46 1 112 1 22  /
+/
+
+EQUALS
+SGL   0.0  1 46 1 112 1 22  /
+SGCR  0.03 1 46 1 112 1 22  /
+SOWCR 0.13 1 46 1 112 1 22  /
+SOGCR 0.07 1 46 1 112 1 22  /
+SWU   1.0  1 46 1 112 1 22  /
+/
+
+-- Hysteresis input
+EHYSTR
+   0.1   0  0.1 1* KR /
+
+COPY
+ 'SWCR'  'ISWCR'   1 46 1 112  5  22 /
+ 'SGU'   'ISGU'    1 46 1 112  5  22 /
+ 'SWL'   'ISWL'    1 46 1 112  5  22 /
+ 'SWU'   'ISWU'    1 46 1 112  5  22 /
+ 'SGL'   'ISGL'    1 46 1 112  5  22 /
+ 'SOGCR' 'ISOGCR'  1 46 1 112  5  22 /
+ 'SOWCR' 'ISOWCR'  1 46 1 112  5  22 /
+ /
+
+EQUALS
+ISGCR 0.22 1 46 1 112  1  22 /
+/
+
+RPTPROPS
+1 1 1 5*0 0 /
+--------------------------------------------------------------------------------
+
+
+REGIONS
+
+--
+INCLUDE
+'./INCLUDE/PETRO/FIPNUM_0704.prop' / 
+
+EQUALS
+'SATNUM'  1    1  46  1   112    1  22  / 
+'IMBNUM'  2    1  46  1   112    1  22  /
+'PVTNUM'  1    1  46  1   112    1  22  /
+/
+
+INCLUDE
+ './INCLUDE/PETRO/EQLNUM_0704.prop' / 
+
+-- extra regions for geological formations and numerical layers 
+--INCLUDE
+-- './INCLUDE/PETRO/EXTRA_REG.inc' / 
+
+---------------------------------------------------------------------------------
+
+SOLUTION
+
+RPTRST
+BASIC=2 KRO KRW KRG /
+
+RPTSOL
+
+FIP=3  SWAT / 
+
+---------------------------------------------------------------------------------
+-- equilibrium data: do not include this file in case of RESTART
+
+INCLUDE
+'./INCLUDE/PETRO/E3.prop' / 
+
+THPRES
+  1 2 0.588031 /
+  2 1 0.588031 /
+  1 3 0.787619 /
+  3 1 0.787619 /
+  1 4 7.00083  /
+  4 1 7.00083  /
+/
+
+-- initialise injected tracers to zero
+TVDPFSEA
+1000   0.0
+5000   0.0 /
+TVDPFHTO
+1000   0.0
+5000   0.0 /
+TVDPFS36
+1000   0.0
+5000   0.0 /
+TVDPF2FB
+1000   0.0
+5000   0.0 /
+TVDPF4FB
+1000   0.0
+5000   0.0 /
+TVDPFDFB
+1000   0.0
+5000   0.0 /
+TVDPFTFB
+1000   0.0
+5000   0.0 /
+
+-------------------------------------------------------------------------------
+
+SUMMARY
+
+NEWTON
+MLINEARS
+
+--
+INCLUDE
+ './INCLUDE/SUMMARY/summary.data' / 
+
+--
+--INCLUDE
+-- './INCLUDE/SUMMARY/extra.inc' /
+
+--
+INCLUDE
+ './INCLUDE/SUMMARY/tracer.data' / 
+--
+INCLUDE
+ './INCLUDE/SUMMARY/gas.inc' / 
+
+--
+INCLUDE
+ './INCLUDE/SUMMARY/wpave.inc' / 
+
+--------------------------------------------------------------------------------
+
+
+SCHEDULE
+
+
+DRSDT
+ 0  /
+
+NOECHO
+
+--------------------------------------------
+--=======Production Wells========--
+-------------------------------------------- 
+
+--
+INCLUDE
+ './INCLUDE/VFP/DevNew.VFP' / 
+
+--
+INCLUDE
+ './INCLUDE/VFP/E1h.VFP' / 
+--
+INCLUDE
+ './INCLUDE/VFP/NEW_D2_GAS_0.00003.VFP' / 
+--
+INCLUDE
+ './INCLUDE/VFP/GAS_PD2.VFP' / 
+--
+INCLUDE
+ './INCLUDE/VFP/AlmostVertNew.VFP' / 
+--
+INCLUDE
+ './INCLUDE/VFP/GasProd.VFP' / 
+  
+ 
+-- 01.01.07 new VFP curves for producing wells, matched with the latest well tests in Prosper. lmarr
+
+--
+INCLUDE
+ './INCLUDE/VFP/B1BH.Ecl' / 
+--
+INCLUDE
+ './INCLUDE/VFP/B2H.Ecl' / 
+--
+INCLUDE
+ './INCLUDE/VFP/B3H.Ecl' / 
+--
+INCLUDE
+ './INCLUDE/VFP/B4DH.Ecl' / 
+--
+INCLUDE
+ './INCLUDE/VFP/D1CH.Ecl' / 
+--
+INCLUDE
+ './INCLUDE/VFP/D2H.Ecl' / 
+--
+INCLUDE
+ './INCLUDE/VFP/D3BH.Ecl' / 
+--
+INCLUDE
+ './INCLUDE/VFP/E1H.Ecl' / 
+--
+INCLUDE
+ './INCLUDE/VFP/E3CH.Ecl' / 
+--
+INCLUDE
+ './INCLUDE/VFP/K3H.Ecl' / 
+ 
+--------------------------------------------
+--=======Production Flowlines========--
+-------------------------------------------- 
+--
+-- 16.5.02 new VFP curves for southgoing PD1,PD2,PB1,PB2 flowlines -> pd2.VFP
+--
+INCLUDE
+ './INCLUDE/VFP/pd2.VFP' / 
+--
+-- 16.5.02 new VFP curves for northgoing PE1,PE2 flowlines -> pe2.VFP
+--
+INCLUDE
+ './INCLUDE/VFP/pe2.VFP' / 
+ 
+  
+-- 24.11.06 new matched VLP curves for PB1 valid from 01.07.06
+--
+INCLUDE
+ './INCLUDE/VFP/PB1.PIPE.Ecl' / 
+
+--24.11.06 new matched VLP curves for PB2 valid from 01.07.06
+--
+INCLUDE
+ './INCLUDE/VFP/PB2.PIPE.Ecl' / 
+
+--24.11.06 new matched VLP curves for PD1 valid from 01.07.06
+--
+INCLUDE
+ './INCLUDE/VFP/PD1.PIPE.Ecl' / 
+
+--24.11.06 new matched VLP curves for PD2 valid from 01.07.06
+--
+INCLUDE
+ './INCLUDE/VFP/PD2.PIPE.Ecl' / 
+
+--24.11.06 new matched VLP curves for PE1 valid from 01.07.06
+--
+INCLUDE
+ './INCLUDE/VFP/PE1.PIPE.Ecl' / 
+
+--24.11.06 new matched VLP curves for PE2 valid from 01.07.06
+--
+INCLUDE
+ './INCLUDE/VFP/PE2.PIPE.Ecl' / 
+  
+   
+-------------------------------------------
+--=======INJECTION FLOWLINES 08.09.2005     ========--
+--------------------------------------------
+-- VFPINJ nr. 10 Water injection flowline WIC 
+--
+INCLUDE
+ './INCLUDE/VFP/WIC.PIPE.Ecl' / 
+
+-- VFPINJ nr. 11 Water injection flowline WIF 
+--
+INCLUDE
+ './INCLUDE/VFP/WIF.PIPE.Ecl' / 
+
+--------------------------------------------
+--=======   INJECTION Wells 08.09.2005       ========--
+--------------------------------------------
+-- VFPINJ nr. 12 Water injection wellbore Norne C-1H 
+--
+INCLUDE
+ './INCLUDE/VFP/C1H.Ecl' / 
+
+-- VFPINJ nr. 13 Water injection wellbore Norne C-2H 
+--
+INCLUDE
+ './INCLUDE/VFP/C2H.Ecl' / 
+
+-- VFPINJ nr. 14 Water injection wellbore Norne C-3H 
+--
+INCLUDE
+ './INCLUDE/VFP/C3H.Ecl' / 
+
+-- VFPINJ nr. 15 Water injection wellbore Norne C-4H 
+--
+INCLUDE
+ './INCLUDE/VFP/C4H.Ecl' / 
+
+-- VFPINJ nr. 16 Water injection wellbore Norne C-4AH 
+--
+INCLUDE
+ './INCLUDE/VFP/C4AH.Ecl' / 
+
+-- VFPINJ nr. 17 Water injection wellbore Norne F-1H 
+--
+INCLUDE
+ './INCLUDE/VFP/F1H.Ecl' / 
+
+-- VFPINJ nr. 18 Water injection wellbore Norne F-2H 
+--
+INCLUDE
+ './INCLUDE/VFP/F2H.Ecl' / 
+
+-- VFPINJ nr. 19 Water injection wellbore Norne F-3 H
+--
+INCLUDE
+'./INCLUDE/VFP/F3H.Ecl' / 
+
+-- VFPINJ nr. 20 Water injection wellbore Norne F-4H 
+--
+INCLUDE
+'./INCLUDE/VFP/F4H.Ecl' / 
+
+TUNING
+1 1.0  0.1  0.15  3  0.3  0.3  1.20  /
+5*   0.1   0.0001   0.02  0.02  /
+2* 40 1* 15 /
+/
+
+-- only possible for ECL 2006.2+ version
+ZIPPY2
+'SIM=4.2' 'MINSTEP=1E-6' /
+
+-- PI reduction in case of water cut
+INCLUDE
+'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+
+-- Schedule including only well B-1H with re-perforations
+INCLUDE
+ './INCLUDE/B1H_RE-PERF.SCH' /
+
+
+END


### PR DESCRIPTION
Test based on NORNE_ATW2013. This model included only one well (B-1H) which original sequence of perforation and then additional perforation. 

WELSPECS is set up with item5 (reference depth) defaulted, which means that this depth is defined from cell center depth of first connection according to COMPORD. 

Notice that reference depth **should not** be reset (updated) when additional perforations (in this case shallower) are added.   

Notice that bottom hole pressure (WBHP:*) is reported at reference depth. 
  