### PR TITLE
Temporarily disable tracer summary output.

### DIFF
--- a/norne/NORNE_ATW2013_B1H_RE-PERF.DATA
+++ b/norne/NORNE_ATW2013_B1H_RE-PERF.DATA
@@ -447,8 +447,8 @@ INCLUDE
 -- './INCLUDE/SUMMARY/extra.inc' /
 
 --
-INCLUDE
- './INCLUDE/SUMMARY/tracer.data' / 
+--INCLUDE
+-- './INCLUDE/SUMMARY/tracer.data' / 
 --
 INCLUDE
  './INCLUDE/SUMMARY/gas.inc' / 


### PR DESCRIPTION
Disable tracer summary output for `norne/NORNE_ATW2013_B1H_RE-PERF.DATA`.
A bit unclear whether this is currently needed also for other norne-related DATA-files.