### PR TITLE
Remove Summary Vectors Particular to Restart Case

### DIFF
--- a/aquifer-oilwater/2D_OW_CTAQUIFER_RESTART.DATA
+++ b/aquifer-oilwater/2D_OW_CTAQUIFER_RESTART.DATA
@@ -811,12 +811,6 @@ AAQT
 AAQP
  1 /
 
-AAQTD
- 1 /
-
-AAQPD
- 1 /
-
 SCHEDULE
 
 SKIPREST


### PR DESCRIPTION
These do not exist in the base run and cause regression failures.