### PR TITLE
Simplify SPE1CASE1_CARFIN.DATA

### DIFF
--- a/lgr/SPE1CASE1_CARFIN.DATA
+++ b/lgr/SPE1CASE1_CARFIN.DATA
@@ -69,10 +69,6 @@ GRID
 CARFIN
 -- NAME I1-I2 J1-J2 K1-K2 NX NY NZ
 'LGR1'  5  6  5  6  1  3  6  6  9 /
-PORO 
-54*0.15 54*0.25 54*0.3 54*0.35 54*0.4 54*0.45 /
-PERMX
-54*150 54*250 54*300 54*350 54*400 54*450 /
 ENDFIN
 
 -- The INIT keyword is used to request an .INIT file. The .INIT file


### PR DESCRIPTION
Simplification following on the discussion on not given priority to redefining grid properties in a LGR.