### PR TITLE
WCONPROD(TARGET) Tests 

### DIFF
--- a/wconprod/WCONPROD-01.DATA
+++ b/wconprod/WCONPROD-01.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-01.DATA
+++ b/wconprod/WCONPROD-01.DATA
@@ -1,0 +1,500 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL:
+--
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   1*     20E3   1*     1*    1*     1*    1000.0                 /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-01: SPE01-TEST01
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     20E3   1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-01.DATA
+++ b/wconprod/WCONPROD-01.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD-02.DATA
+++ b/wconprod/WCONPROD-02.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-02.DATA
+++ b/wconprod/WCONPROD-02.DATA
@@ -1,0 +1,500 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL:
+--
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   1*     1*     1*     1*    20E3   1*    1000.0                 /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-02: SPE01-TEST02
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    20E3   1*     1000.0                /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-02.DATA
+++ b/wconprod/WCONPROD-02.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD-03.DATA
+++ b/wconprod/WCONPROD-03.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-03.DATA
+++ b/wconprod/WCONPROD-03.DATA
@@ -1,0 +1,500 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL
+--
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   1*     1*     1*     5E3   20E3   1*     1000.0                /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-03: SPE01-TEST03
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     5E3   20E3   1*     1000.0                /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-03.DATA
+++ b/wconprod/WCONPROD-03.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD-04.DATA
+++ b/wconprod/WCONPROD-04.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-04.DATA
+++ b/wconprod/WCONPROD-04.DATA
@@ -1,0 +1,500 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL
+--
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   1*     1*     5E3    5E3   20E3   1*     1000.0                /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-04: SPE01-TEST04
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     5E3    5E3   20E3   1*     1000.0                /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-04.DATA
+++ b/wconprod/WCONPROD-04.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD-05.DATA
+++ b/wconprod/WCONPROD-05.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-05.DATA
+++ b/wconprod/WCONPROD-05.DATA
@@ -1,0 +1,516 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL and OP01 under Group LIQ control:
+--
+-- --
+-- --       GROUP PRODUCTION CONTROLS                                                    
+-- --                                                                              
+-- -- GRUP  CNTL  OIL    WAT    GAS    LIQ    CNTL  GRUP  GUIDE  GUIDE  CNTL                      
+-- -- NAME  MODE  RATE   RATE   RATE   RATE   OPT   CNTL  RATE   DEF    WAT                       
+-- GCONPROD                                                                        
+-- FIELD    LRAT  10E3   1*     1*     20E3   1*     1*    1*     1*     1*       /
+-- /                                                                               
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   1*     20E3   1*     1*    1*     1*    1000.0                 /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-05: SPE01-TEST05
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       GROUP PRODUCTION CONTROLS                                                    
+--                                                                              
+-- GRUP  CNTL  OIL    WAT    GAS    LIQ    CNTL  GRUP  GUIDE  GUIDE  CNTL                      
+-- NAME  MODE  RATE   RATE   RATE   RATE   OPT   CNTL  RATE   DEF    WAT                       
+GCONPROD                                                                        
+FIELD    LRAT  10E3   1*     1*     20E3   1*     1*    1*     1*     1*       /
+/                                                                               
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     20E3   1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-05.DATA
+++ b/wconprod/WCONPROD-05.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD-06.DATA
+++ b/wconprod/WCONPROD-06.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-06.DATA
+++ b/wconprod/WCONPROD-06.DATA
@@ -1,0 +1,500 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL:
+--
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   ''     20E3   1*     1*    1*     1*    1000.0                 /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-06: SPE01-TEST06
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   ''     20E3   1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-06.DATA
+++ b/wconprod/WCONPROD-06.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD-07.DATA
+++ b/wconprod/WCONPROD-07.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-07.DATA
+++ b/wconprod/WCONPROD-07.DATA
@@ -1,0 +1,500 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL:
+--
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   ''     1*     1*     1*    20E3   1*    1000.0                 /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-07: SPE01-TEST07
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   ''     1*     1*     1*    20E3   1*     1000.0                /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-07.DATA
+++ b/wconprod/WCONPROD-07.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD-08.DATA
+++ b/wconprod/WCONPROD-08.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-08.DATA
+++ b/wconprod/WCONPROD-08.DATA
@@ -1,0 +1,500 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL
+--
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   ''     1*     1*     5E3   20E3   1*     1000.0                /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-08: SPE01-TEST08
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   ''     1*     1*     5E3   20E3   1*     1000.0                /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-08.DATA
+++ b/wconprod/WCONPROD-08.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD-09.DATA
+++ b/wconprod/WCONPROD-09.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-09.DATA
+++ b/wconprod/WCONPROD-09.DATA
@@ -1,0 +1,500 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL
+--
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   ''     1*     5E3    5E3   20E3   1*     1000.0                /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-09: SPE01-TEST09
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   ''     1*     5E3    5E3   20E3   1*     1000.0                /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-09.DATA
+++ b/wconprod/WCONPROD-09.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD-10.DATA
+++ b/wconprod/WCONPROD-10.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-10.DATA
+++ b/wconprod/WCONPROD-10.DATA
@@ -1,0 +1,516 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL and OP01 under Group LIQ control:
+--
+-- --
+-- --       GROUP PRODUCTION CONTROLS                                                    
+-- --                                                                              
+-- -- GRUP  CNTL  OIL    WAT    GAS    LIQ    CNTL  GRUP  GUIDE  GUIDE  CNTL                      
+-- -- NAME  MODE  RATE   RATE   RATE   RATE   OPT   CNTL  RATE   DEF    WAT                       
+-- GCONPROD                                                                        
+-- FIELD    LRAT  10E3   1*     1*     20E3   1*     1*    1*     1*     1*       /
+-- /                                                                               
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   ''     20E3   1*     1*    1*     1*    1000.0                 /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-10: SPE01-TEST10
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       GROUP PRODUCTION CONTROLS                                                    
+--                                                                              
+-- GRUP  CNTL  OIL    WAT    GAS    LIQ    CNTL  GRUP  GUIDE  GUIDE  CNTL                      
+-- NAME  MODE  RATE   RATE   RATE   RATE   OPT   CNTL  RATE   DEF    WAT                       
+GCONPROD                                                                        
+FIELD    LRAT  10E3   1*     1*     20E3   1*     1*    1*     1*     1*       /
+/                                                                               
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   ''     20E3   1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-10.DATA
+++ b/wconprod/WCONPROD-10.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD-11.DATA
+++ b/wconprod/WCONPROD-11.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-11.DATA
+++ b/wconprod/WCONPROD-11.DATA
@@ -1,0 +1,500 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL:
+--
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   1*     1*     1*     1*    1*     1*     1*                    /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-11: SPE01-TEST11
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*     1*                    /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-11.DATA
+++ b/wconprod/WCONPROD-11.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD-12.DATA
+++ b/wconprod/WCONPROD-12.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD-12.DATA
+++ b/wconprod/WCONPROD-12.DATA
@@ -1,0 +1,500 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2 used to test the following, with WELSPEC(TYPE) equal to OIL:
+--
+-- --       WELL PRODUCTION WELL CONTROLS
+-- --
+-- -- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP
+-- -- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ
+-- WCONPROD
+-- OP01     OPEN   ''     1*     1*     1*    1*     1*     1*                    /
+-- /
+--
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD-12: SPE01-TEST12
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   ''     1*     1*     1*    1*     1*     1*                    /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD-12.DATA
+++ b/wconprod/WCONPROD-12.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD.DATA
+++ b/wconprod/WCONPROD.DATA
@@ -1,28 +1,11 @@
--- *********************************************************************************************************************************
 --                                                                              
---                                              OPM FLOW SIMULATION FILE  
---                                                                              
---                                                                              
--- COPYRIGHT NOTICE
--- ----------------
--- This file is part of the Open Porous Media project (OPM).
---
--- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
--- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
---
--- This file is made available under the Open Database License: 
---                                    http://opendatacommons.org/licenses/odbl/1.0/.
---
--- Any rights in individual contents of the database are licensed under the Database Contents License:
---                                    http://opendatacommons.org/licenses/dbcl/1.0/
---
--- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
---
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+--  
 -- Copyright (C) 2022 Equinor ASA
---
--- COMMENTS                                                                    
--- --------                                                                    
+--                                                                         
 -- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
 --
 --    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,

--- a/wconprod/WCONPROD.DATA
+++ b/wconprod/WCONPROD.DATA
@@ -1,0 +1,492 @@
+-- *********************************************************************************************************************************
+--                                                                              
+--                                              OPM FLOW SIMULATION FILE  
+--                                                                              
+--                                                                              
+-- COPYRIGHT NOTICE
+-- ----------------
+-- This file is part of the Open Porous Media project (OPM).
+--
+-- OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+--
+-- This file is made available under the Open Database License: 
+--                                    http://opendatacommons.org/licenses/odbl/1.0/.
+--
+-- Any rights in individual contents of the database are licensed under the Database Contents License:
+--                                    http://opendatacommons.org/licenses/dbcl/1.0/
+--
+-- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
+--
+-- Copyright (C) 2020 Equinor ASA
+--
+-- COMMENTS                                                                    
+-- --------                                                                    
+-- This simulation is based on the SPE Comparison Case Number 01 based on the data given in:
+--
+--    'Comparison of Solutions to a Three-Dimensional Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+--    Journal of Petroleum Technology, January 1981
+--                                                                             
+-- There are two version of this SPE case based on how gas resolution is modeled. If DRSDT is set to 0, GOR cannot rise and free 
+-- gas does not dissolve in undersaturated oil and implies a constant bubble point pressure, or full resolution. This is controlled 
+-- by the DRSDT keyword in the SCHEDULE. The two cases are therefore:
+--
+--    (1) Case 1 - Has no resolution of the gas and has the following twoSPE01-CASE02-OPM1910-R01.DATA lines in the SCHEDULE 
+--        section:
+--
+--          DRSDT
+--          0 /
+--
+--    (2) Case 2 - Has full resolution of the gas and therefore the DRSDT keyword is commented out:
+--
+--          -- DRSDT
+--          -- 0 /
+--
+-- This run is for SPE01 Case 2
+--                                                                             
+-- 456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012
+--       1         2         3         4         5         6         7         8         9         0         1         2         3  
+--       0         0         0         0         0         0         0         0         0         1         1         1         1  
+-- *********************************************************************************************************************************
+--
+-- =================================================================================================================================
+-- 
+-- RUNSPEC SECTION 
+-- 
+-- =================================================================================================================================
+RUNSPEC
+--
+--       DEFINE THE TITLE FOR THE RUN  
+--
+TITLE                                                                           
+WCONPROD: SPE01-CASE02-OPM2010-R01.DATA - FULL GAS RESOLUTION SCENARIO
+--
+--       DEFINE THE START DATE FOR THE RUN 
+--
+START                                                                                                                                                                                                     
+         01 'JAN' 2015                                                         /                                                                               
+--                                                                              
+--       SWITCH NO SIMULATION MODE FOR DATA CHECKING COMMENT OUT TO RUN THE MODEL
+--
+-- NOSIM                                                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID TYPES AND TRACER OPTIONS                         
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       OIL PHASE IS PRESENT IN THE RUN
+--
+OIL                                                                            
+--
+--       WATER PHASE IS PRESENT IN THE RUN
+--
+WATER                                                                            
+--
+--       GAS PHASE IS PRESENT IN THE RUN
+--
+GAS                                                                                                                                                           
+--
+--       DISSOLVED GAS IN LIVE OIL IS PRESENT IN THE RUN
+--
+DISGAS                                                                            
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GRID AND EQUILBRATION DIMENSIONS AND OPTIONS                                             
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                              
+--       MAX     MAX     MAX                                                    
+--       NDIVIX  NDIVIY  NDIVIZ                                                 
+DIMENS                                                                          
+         10      10      3                                                     / 
+--                                                                              
+--       MAX     MAX     RSVD    TVDP    TVDP                                   
+--       EQLNUM  DEPTH   NODES   TABLE   NODES                                  
+EQLDIMS                                                                         
+         1*      1*      1*      1*      1*                                    /                                                                          
+--                                                                              
+--       MAX     TOTAL   INDEP   FLUX    TRACK  CBM    OPERN  WORK  WORK  POLY
+--       FIPNUM  REGNS   REGNS   REGNS   REGNS  REGNS  REGNS  REAL  INTG  REGNS 
+REGDIMS                                                                         
+         1*      1*      1*      1*      1*     1*     1*     1*    1*    1*   /                
+--
+--       NEG      MAX     MAX                                                    
+--       MULTS    MULTNUM PINCHNUM                                               
+GRIDOPTS                                                                        
+         NO       1*       1*                                                  /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       MAX     MAX     MAX     MAX     MAX     MAX    E300                    
+--       NTSFUN  NTPVT   NSSFUN  NPPVT   NTFIP   NRPVT  BLANK  NTEND            
+TABDIMS                                                                         
+         1*      1*      1*      1*      1*      1*     1*     1*              /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- GROUP, WELL AND VFP TABLE DIMENSIONS                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                
+--       WELL    WELL    GRUPS   GRUPS                                          
+--       MXWELS  MXCONS  MXGRPS  MXGRPW                                         
+WELLDIMS                                                                        
+         2       1       1       2                                             /                                                                                
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- INPUT AND OUTPUT OPTIONS                                                   
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--
+--       FIELD SYSTEM OF UNITS FOR BOTH INPUT AND OUTPUT 
+--
+FIELD 
+--
+--       SWITCH ON THE UNIFIED INPUT FILES OPTION
+--
+UNIFIN                                                                          
+--
+--       SWITCH ON THE UNIFIED OUTPUT FILES OPTION
+--
+UNIFOUT                                                                          
+--                                                                                
+--       MESS  COMMT WARN  PROBL ERROR BUG   MESS COMMT WARN  PROBL ERROR BUG      
+--       LIMIT LIMIT LIMIT LIMIT LIMIT LIMIT STOP STOP  STOP  STOP  STOP  STOP     
+MESSAGES                                                                        
+         3000  1*    1000  1000  1*    1*    1*   1*    9000  1*    9000  1*   /        
+--
+--       DEBUG PRINTING OPTIONS
+--
+DEBUG                                                                           
+         8*0   1     11*0  1     30*0                                          /                                                                               
+-- =================================================================================================================================
+-- 
+-- GRID SECTION 
+-- 
+-- =================================================================================================================================
+GRID
+
+--
+--       ACTIVATE WRITING THE INIT FILE FOR POST-PROCESSING
+--
+INIT
+--
+--       GRID FILE OUTPUT OPTIONS
+--       GRID    EGRID
+--       OPTN    OPTN
+GRIDFILE
+         0       1                                                             /                                                                              
+--                                                                              
+--       DEFINE GRID BLOCK X DIRECTION CELL SIZE                            
+-- 
+DX
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Y DIRECTION CELL SIZE                            
+-- 
+DY
+         300*1000                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK Z DIRECTION CELL SIZE                            
+-- 
+DZ
+         100*20.0   100*30.0   100*50.0                                        /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK TOPS FOR THE TOP LAYER                         
+-- 
+TOPS
+         100*8325                                                              /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK POROSITY DATA FOR ALL CELLS                            
+-- 
+PORO
+         300*0.300                                                             /                                                                                 
+--                                                                              
+--       DEFINE GRID BLOCK PERMX DATA FOR ALL CELLS                          
+-- 
+PERMX
+         100*500.0   100*50.0   100*200.0                                      /                                                                                                                                                                                                                                                                               
+--
+--       SOURCE      DESTIN.      ---------- BOX ---------            
+--                                I1  I2   J1  J2   K1  K2            
+COPY                                                            
+         PERMX       PERMY        1*  1*   1*  1*   1*  1* / CREATE PERMY 
+         PERMX       PERMZ        1*  1*   1*  1*   1*  1* / CREATE PERMZ        
+/                                                               
+         
+-- =================================================================================================================================
+-- 
+-- PROPS SECTION 
+-- 
+-- =================================================================================================================================
+PROPS
+
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- FLUID PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       GAS PVT TABLE FOR DRY GAS                                                                        
+--                                                                                      
+PVDG
+--       PRES     BG          VISC                                                         
+--       PSIA     RB/MSCF     CPOISE                                                        
+--       ------   --------    ------                                                
+         14.700   166.666     0.00800
+         264.70   12.0930     0.00960
+         514.70   6.27400     0.01120
+         1014.7   3.19700     0.01400
+         2014.7   1.61400     0.01890
+         2514.7   1.29400     0.02080
+         3014.7   1.08000     0.02280
+         4014.7   0.81100     0.02680
+         5014.7   0.64900     0.03090
+         9014.7   0.38600     0.04700                      / TABLE NO. 01
+--                                                                                      
+--       OIL PVT TABLE FOR LIVE OIL                                                                 
+--                                                                                      
+PVTO                                                                                    
+--       RS        PSAT       BO        VISC                                                  
+--       MSCF/STB  PSIA       RB/STB    CPOISE                                                
+--       --------  --------   -------   ------                                                
+          0.0010      14.7    1.0620    1.0400             /
+          0.0905     264.7    1.1500    0.9750             /
+          0.1800     514.7    1.2070    0.9100             /
+          0.3710    1014.7    1.2950    0.8300             /
+          0.6360    2014.7    1.4350    0.6950             /
+          0.7750    2514.7    1.5000    0.6410             /
+          0.9300    3014.7    1.5650    0.5940             /
+          1.2700    4014.7    1.6950    0.5100             
+                    9014.7    1.5790    0.7400             /
+          1.6180    5014.7    1.8270    0.4490             
+                    9014.7    1.7370    0.6310             / 
+                                                           / TABLE NO. 01                                       
+--                                                                                      
+--       WATER PVT TABLE                                                                    
+--                                                                                      
+PVTW                                                                                    
+--       REF PRES  BW         CW        VISC     VISC                                         
+--       PSIA      RB/STB     1/PSIA    CPOISE   GRAD                                         
+--       --------  --------   -------   ------   ------                                       
+         4017.55   1.038      3.22E-6   0.318    0.0       / TABLE NO. 01
+--
+--       OIL      WAT        GAS                                                             
+--       DENSITY  DENSITY    DENSITY                                                       
+--       -------  -------    -------                                                         
+DENSITY                                                                                  
+         53.66    64.49      0.0533                        / DENSITY PVT DATA REGION 1
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- ROCK PROPERTIES
+-- ---------------------------------------------------------------------------------------------------------------------------------
+--                                                                                      
+--       REFERENCE PRESSURE IS TAKEN FROM THE HCPV WEIGHTED FIELD RESERVOIR PRESSURE      
+--       AS THE PORV IS ALREADY AT RESERVOIR CONDITIONS (ECLIPSE USES THE REFERENCE       
+--       PRESSURE) TO CONVERT THE GIVEN PORV TO RESERVOIR CONDITIONS USING THE DATA       
+--       ON THE ROCK KEYWORD)                                                             
+--                                                                                      
+--       REF PRES  CF                                                                         
+--       PSIA      1/PSIA                                                                     
+--       --------  --------                                                                   
+ROCK                                                                                    
+         14.7      3.0E-06                                 / ROCK COMPRSSIBILITY                       
+--                                                                                     
+--       GAS-OIL RELATIVE PERMEABILITY TABLES (SGOF)      
+--
+SGOF
+--       SG         KRG       KROG      PCOG                                                     
+--       FRAC                           PSIA                                                  
+--       -------   --------  -------   -------                                                
+         0.00000   0.000000  1.00000    0.0000
+         0.00100   0.000000  1.00000    0.0000
+         0.02000   0.000000  0.99700    0.0000
+         0.05000   0.005000  0.98000    0.0000
+         0.12000   0.025000  0.70000    0.0000
+         0.20000   0.075000  0.35000    0.0000
+         0.25000   0.125000  0.20000    0.0000
+         0.30000   0.190000  0.09000    0.0000
+         0.40000   0.410000  0.02100    0.0000
+         0.45000   0.600000  0.01000    0.0000
+         0.50000   0.720000  0.00100    0.0000
+         0.60000   0.870000  0.00010    0.0000
+         0.70000   0.940000  0.00000    0.0000
+         0.85000   0.980000  0.00000    0.0000 
+         0.88000   0.984000  0.00000    0.0000             / TABLE No. 01
+--                                                                                     
+--       WATER-OIL RELATIVE PERMEABILITY TABLES (SWOF)                                                                  
+-- 
+SWOF
+--       SWAT       KRW                   KROW      PCOW                                               
+--       FRAC                                       PSIA                                            
+--       --------   ------------------    -------   -------                                          
+         0.120000  0.00000000000000E-000  1.0000    0.0000
+         0.180000  4.64876033057851E-008  1.0000    0.0000
+         0.240000  0.00000018600000E-000  0.9970    0.0000
+         0.300000  4.18388429752066E-007  0.9800    0.0000
+         0.360000  7.43801652892562E-007  0.7000    0.0000
+         0.420000  1.16219008264463E-006  0.3500    0.0000
+         0.480000  1.67355371900826E-006  0.2000    0.0000
+         0.540000  2.27789256198347E-006  0.0900    0.0000
+         0.600000  2.97520661157025E-006  0.0210    0.0000
+         0.660000  3.76549586776860E-006  0.0100    0.0000
+         0.720000  4.64876033057851E-006  0.0010    0.0000
+         0.780000  0.00000562500000E-000  0.0001    0.0000
+         0.840000  6.69421487603306E-006  0.0000    0.0000
+         0.910000  8.05914256198347E-006  0.0000    0.0000
+         1.000000  0.00001000000000E-000  0.0000    0.0000 / TABLE NO. 01
+
+-- =================================================================================================================================
+-- 
+-- REGIONS SECTION 
+-- 
+-- =================================================================================================================================
+REGIONS
+
+-- =================================================================================================================================
+-- 
+-- SOLUTION SECTION 
+-- 
+-- =================================================================================================================================
+SOLUTION
+
+--
+--       DATUM   DATUM   OWC     PCOW   GOC    PCGO   RS   RV   N           
+--       DEPTH   PRESS   DEPTH   ----   DEPTH  ----   OPT  OPT  OPT         
+EQUIL 
+         8400.0  4800.0  8450.0  0      8300.0 0      1    0    0              /
+--
+--       DEPTH    RS                                                 
+--                MSCF/STB                                                  
+--       ------   --------                                                               
+RSVD            
+         8300.0    1.270
+         8450.0    1.270                                   / RS VS DEPTH EQUIL REGN 01
+
+-- =================================================================================================================================
+-- 
+-- SUMMARY SECTION 
+-- 
+-- =================================================================================================================================
+SUMMARY 
+--
+--       EXPORT STANDARD SUMMARY VARIABLE VECTORS TO FILE
+--
+ALL
+--
+--       PRESSURES OF THE CELL WHERE THE INJECTOR AND PRODUCER ARE LOCATED
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BPR                   
+         1    1    1    /
+         10   10   3    /
+/
+--
+--       GAS SATURATION AT GRID POINTS GIVEN IN THE PAPER BY ODEH
+--
+--       --- GRID ---                
+--       I1   J1   K1                 
+BGSAT
+         1    1    1    /
+         1    1    2    /
+         1    1    3    /
+         10   1    1    /                                        
+         10   1    2    /
+         10   1    3    /
+         10   10   1    /
+         10   10   2    /
+         10   10   3    /
+/                       
+--
+--       ACTIVATE COLUMNAR SUMMARY DATA REPORTING OPTION     
+--
+RUNSUM                                               
+--
+--       ACTIVATE SUMMARY DATA RSM FILE OUTPUT OPTION     
+--
+SEPARATE   
+
+-- =================================================================================================================================
+--
+-- SCHEDULE SECTION
+--
+-- =================================================================================================================================
+SCHEDULE
+
+--
+--       DEFINE SCHEDULE SECTION REPORT OPTION
+--
+RPTSCHED
+         'WELLS=2'                                                             /
+--
+--       RESTART CONTROL BASIC = 4 (ALL=2, YEARLY=4, MONTHLY=5, TSTEP=6)
+--
+RPTRST                                                                           
+         'BASIC=1'                                                             /
+--                                                                                     
+--       SOLUTION GAS (RS) MAXIMUM RATE OF INCREASE FOR MODEL                                            
+--       CASE 2 NO GAS RESOLUTION
+-- DRSDT
+--       MAX RS    ALL/FREE                                                  
+--       DRSDT1    DRSDT2                             
+--       -------   --------                                          
+--       0.000     1*                                      /
+-- ---------------------------------------------------------------------------------------------------------------------------------
+-- WELL SPECIFICATIONS AND COMPLETIONS                                          
+-- ---------------------------------------------------------------------------------------------------------------------------------      
+--
+--       WELL SPECIFICATION DATA                                                      
+--                                                                              
+-- WELL  GROUP     LOCATION  BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT         
+-- NAME  NAME        I    J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE       
+WELSPECS                                                                                                                                                           
+OP01     MAIN       10   10 8400     OIL    1*     1*     SHUT   1*     1*     /
+GI01     MAIN        1    1 8335     GAS    1*     1*     SHUT   1*     1*     /
+/   
+--
+--       WELL CONNECTION DATA                           
+--                                                                              
+-- WELL  --- LOCATION ---  OPEN   SAT   CONN   WELL   KH    SKIN   D     DIR   
+-- NAME   II  JJ  K1  K2   SHUT   TAB   FACT   DIA    FACT  FACT   FACT  PEN   
+COMPDAT                                                                        
+OP01      10  10   3   3   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+GI01       1   1   1   1   OPEN   1*    1*    0.500   1*    1*     1*    'Z'   /
+/                                                                              
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   ORAT   20E3   1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       WELL INJECTION CONTROLS                                                      
+--                                                                              
+-- WELL  FLUID  OPEN/  CNTL  SURF   RESV   BHP   THP   VFP               
+-- NAME  TYPE   SHUT   MODE  RATE   RATE   PRSES PRES  TABLE             
+WCONINJE                                                                        
+GI01     GAS    OPEN   RATE 100E3   1*     9014   1*    1*                     /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+31
+/ 
+--
+--       WELL PRODUCTION WELL CONTROLS                                                     
+--                                                                              
+-- WELL  OPEN/  CNTL   OIL    WAT    GAS   LIQ    RES    BHP   THP   VFP    VFP  
+-- NAME  SHUT   MODE   RATE   RATE   RATE  RATE   RATE   PRES  PRES  TABLE  ALFQ 
+WCONPROD                                                                    
+OP01     OPEN   1*     1*     1*     1*    1*     1*    1000.0                 /
+/                                                                               
+--
+--       ADVANCE SIMULATION BY REPORTING TIME
+--
+--       JAN  FEB  MAR  APR  MAY  JUN  JLY  AUG  SEP  OCT  NOV  DEC
+TSTEP                                                                           
+28
+/ 
+
+END
+        
+ECHO        
+--                                                                              
+-- *********************************************************************************************************************************
+-- END OF FILE                                                                  
+-- *********************************************************************************************************************************

--- a/wconprod/WCONPROD.DATA
+++ b/wconprod/WCONPROD.DATA
@@ -19,7 +19,7 @@
 -- OPM is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the aforementioned GNU General Public Licenses for more details.
 --
--- Copyright (C) 2020 Equinor ASA
+-- Copyright (C) 2022 Equinor ASA
 --
 -- COMMENTS                                                                    
 -- --------                                                                    

--- a/wconprod/WCONPROD.md
+++ b/wconprod/WCONPROD.md
@@ -1,0 +1,39 @@
+# WCONPROD Test Documentation
+
+Case Name  | Case Desciption                                          | Base Model | Results<br />Match | Comments |
+---------  | -----------------------------                            | ---------- | ------- | ------------------------------------- |
+WCONPROD   | Base case model base on SPE01 Case 2                     | WCONPROD   | Complete| Runs as expected, but results are different.
+WCONPROD-01| STATUS=1*, ORAT=20E3, BHP=1000.0 only                    | WCONPROD   | Fails   | Issues error message and continues, but then fails. 
+WCONPROD-02| STATUS=1*, LRAT=20E3, BHP=1000.0 only                    | WCONPROD   | Fails   | Issues error message and continues, but then fails.
+WCONPROD-03| STATUS=1*, LRAT=20E3, BHP=1000.0 GRAT=5E3 only           | WCONPROD   | Fails   | Issues error message and continues, but then fails. 
+WCONPROD-04| STATUS=1*, LRAT=20E3, BHP=1000.0 GRAT=5E3, WRAT=5E3 only | WCONPROD   | Fails   | Issues error message and continues, but then fails. 
+WCONPROD-05| STATUS=1*, ORAT=20E3, BHP=1000.0, and group constraints  | WCONPROD   | Fails   | Issues error message and continues, but then fails.
+WCONPROD-06| STATUS='', ORAT=20E3, BHP=1000.0 only                    | WCONPROD   | Fails   | Error: WCONPROD,Internal error: Unknown enum state string
+WCONPROD-07| STATUS='', LRAT=20E3, BHP=1000.0 only                    | WCONPROD   | Fails   | Error: WCONPROD,Internal error: Unknown enum state string
+WCONPROD-08| STATUS='', LRAT=20E3, BHP=1000.0 GRAT=5E3 only           | WCONPROD   | Fails   | Error: WCONPROD,Internal error: Unknown enum state string
+WCONPROD-09| STATUS='', LRAT=20E3, BHP=1000.0 GRAT=5E3, WRAT=5E3 only | WCONPROD   | Fails   | Error: WCONPROD,Internal error: Unknown enum state string
+WCONPROD-10| STATUS='', ORAT=20E3, BHP=1000.0, and group constraints  | WCONPROD   | Fails   | Error: WCONPROD,Internal error: Unknown enum state string
+WCONPROD-11| STATUS=1*, only                                          | WCONPROD   | Fails   | Issues error message and continues, but then fails. 
+WCONPROD-12| STATUS='', only                                          | WCONPROD   | Fails   | Error: WCONPROD,Internal error: Unknown enum state string
+   
+The default tokens of 1* and '' should behave the same; however, the actual values used when WCONPROD(TARGET) is defaulted is variable, as outlined below:
+
+*   If the well is **not** under group control, then WCONPROD(TARGET) is set to the first non-defaulted hydrocarbon rate (ORAT, GRAT, LIQ, RESV). 
+    If all rates are defaulted and BHP is entered, then the BHP is used. It is assumed that if the BHP is defaulted as well, and THP has been entered, 
+    then THP would be used (this configuration has not been tested). Finally, if all parameters are defaulted, then the default value of BHP (14.70 psia) 
+    will be used combined with BHP control.
+    In all the above scenarios the well has been declared as open, that is WCONPROD(STATUS) is set to OPEN.
+
+*   If, **and only if**, the well’s group parameters have been defined via the GCONPROD keyword, then WCONPROD(TARGET) is set equal to GRUP.  
+
+In summary, for wells belonging to groups, where GCONPROD has **not** been set or defined, then WCONPROD(TARGET) is defined as the first non-defaulted value on the WCONPROD keyword,
+except for WAT control mode. If all parameters are defaulted, then the default BHP value is used and the WCONPROD(TARGET) is set to BHP.
+ 
+**Notes:** 
+
+1.   _Results Match_ column indicate if the OPM Flow results match the commercial simulator Currently, there is WCONPROD.odp document at the moment.
+2.   Under comments, _Complete_ means that the test case is completed, it does not mean that the runs are necessarily comparable to the commercial simulator.
+
+
+**Version: 01 August, 2022**
+                                        


### PR DESCRIPTION
The default tokens of 1* and '' should behave the same; however, the actual values used when WCONPROD(TARGET) is defaulted is variable, as outlined below:

If the well is not under group control, then WCONPROD(TARGET) is set to the first non-defaulted hydrocarbon rate (ORAT, GRAT, LIQ, RESV). If all rates are defaulted and BHP is entered, then the BHP is used. It is assumed that if the BHP is defaulted as well, and THP has been entered, then THP would be used (this configuration has not been tested). Finally, if all parameters are defaulted, then the default value of BHP (14.70 psia) will be used combined with BHP control. In all the above scenarios the well has been declared as open, that is WCONPROD(STATUS) is set to OPEN.

If, and only if, the well’s group parameters have been defined via the GCONPROD keyword, then WCONPROD(TARGET) is set equal to GRUP.

In summary, for wells belonging to groups, where GCONPROD has not been set or defined, then WCONPROD(TARGET) is defined as the first non-defaulted value on the WCONPROD keyword, except for WAT control mode. If all parameters are defaulted, then the default BHP value is used and the WCONPROD(TARGET) is set to BHP.

