### PR TITLE
Testing directional relative permeabilities with hysteresis

### DIFF
--- a/model2/7_HYSTERESIS_MODEL2_DIRECT.DATA
+++ b/model2/7_HYSTERESIS_MODEL2_DIRECT.DATA
@@ -1,0 +1,306 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2018 Equinor
+
+-- Testing hysteresis option, keyword SATOPTS, EHYSTR, ISGL, ISGU, ISWCR, ISWL, IMBNUM.
+-- Testing directional permeabilities: KRNUMX, KRNUMY, KRNUMZ, IMBNUMX, IMBNUMY, IMBNUMZ
+
+-- ------------------------------------------------------------------------
+-- ----------------------- BASE MODEL 1 -----------------------------------
+-- ------------------------------------------------------------------------
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 13 22 11 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+--
+GRIDOPTS
+ 'YES'	      0 /
+
+EQLDIMS
+ 2  100  25 /
+
+
+EQLOPTS
+ THPRES  /
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   2          1       1*            2    /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10	    15 	          3	     10   /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  10          1      50          60         2         60 /
+
+SATOPTS
+ HYSTER DIRECT
+/
+
+VFPPDIMS
+--max.rate  max.THP   max.fw   max.fg	max.ALQ    max.tabs
+  40	    20        20       20	0	   60	    /
+
+--
+FAULTDIM
+120 / max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+0  1/
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+--
+PINCH
+ 0.001   GAP  1*   TOPBOT   ALL /
+
+MINPVV
+ 1144*100 2002*300 /
+
+
+
+INCLUDE
+ 'include/mod2a_13x22x11.grdecl' /
+
+INCLUDE
+ 'include/fluxmun.grdecl' /
+
+
+INCLUDE
+ 'include/faults.grdecl' /
+
+
+INCLUDE
+ 'include/poro.grdecl' /
+
+INCLUDE
+ 'include/permx.grdecl' /
+
+INCLUDE
+ 'include/ntg.grdecl' /
+
+
+INCLUDE
+ 'include/multz.grdecl' /
+
+INCLUDE
+ 'include/multx.grdecl' /
+
+INCLUDE
+ 'include/multy.grdecl' /
+
+COPY
+ PERMX PERMY /
+/
+
+
+INCLUDE
+ 'include/permz.grdecl'/
+
+
+MULTREGT
+ 1  2	 0.0  2* F /
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+
+------------------------------------------------------------------------------------------------
+EDIT
+------------------------------------------------------------------------------------------------
+
+MULTFLT
+ 'F1'  0.1 /
+ 'F2'  0.2 /
+ 'F3'  0.3 /
+ 'F4'  0.4 /
+/
+
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/norne_pvt.inc' /
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm_ow.inc' /
+
+INCLUDE
+ 'include/relperm_go.inc' /
+
+INCLUDE
+ 'include/swatinit.grdecl' /
+
+
+INCLUDE
+ 'include/swl.grdecl' /
+
+-- SWCR = SWL
+COPY
+  SWL  SWCR /
+/
+
+EQUALS
+ 'SGL' 0.0 /
+/
+
+-- SGU = 1-SWL
+INCLUDE
+ 'include/sgu.grdecl' /
+
+
+EHYSTR
+      0.1  1  0.1 1* KR /
+      
+
+
+COPY
+ 'SGL' 'ISGL'   /
+ 'SGU' 'ISGU'   /
+ 'SWCR' 'ISWCR' /
+ 'SWL' 'ISWL'   /
+/
+
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+INCLUDE
+ 'include/eqlnum.grdecl' /
+
+INCLUDE
+ 'include/fipnum.grdecl' /
+
+INCLUDE
+ 'include/satnum.grdecl' /
+
+INCLUDE
+ 'include/imbnum.grdecl' /
+
+KRNUMX
+ 3146*1/
+
+KRNUMY
+ 3146*1/
+
+KRNUMZ
+ 3146*2/
+
+IMBNUMX
+ 3146*5/
+
+IMBNUMY
+ 3146*5/
+
+IMBNUMZ
+ 3146*6/
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2561.59  268.55  2645.21   0.0 2561.59  0.0   1   0   0 /
+ 2584.20  268.71 2685.21   0.0 2584.20  0.0   5   0   0 /
+
+RSVD
+ 2561.59  122.30
+ 2597.0  110.00
+ 2660.7  106.77
+ 2697.0  106.77 /
+
+ 2584.20  122.41
+ 2599.9  110.00
+ 2663.6  106.77
+ 2699.9  106.77 /
+
+
+THPRES
+ 1  2 /
+/
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+RPTRST
+ 'BASIC=2' /
+
+
+INCLUDE
+ 'include/D-1.Ecl' /
+
+
+INCLUDE
+ 'include/hist_schedule.sch' /
+
+
+END


### PR DESCRIPTION
This test case is a slight modification of `7_HYSTERESIS_MODEL2.DATA`. It adds "DIRECT" to the SATOPTS keyword such that reversible directional relative permeabilities are enabled. According to this option, special satnum tables for drainage and hysteresis across X-, Y-, and Z-faces are set up using the KRNUMX, KRNUMY, and KRNUMZ keywords for drainage, and IMBNUMX, IMBNUMY, and IMBNUMZ for imbibition.
