### PR TITLE
Comment out NONNC in SPE10 Cases

### DIFF
--- a/spe10/SPE10-MOD01-01.DATA
+++ b/spe10/SPE10-MOD01-01.DATA
@@ -83,9 +83,9 @@ REGDIMS
 GRIDOPTS
          NO       1*      1*                                                   /
 --
---       DEACTIVATES NON-NEIGHBOR CONNECTIONS
+--       DEACTIVATES NON-NEIGHBOR CONNECTIONS (NOT SUPPORTED)
 --
-NONNC
+--       NONNC
 -- ---------------------------------------------------------------------------------------------------------------------------------
 -- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS
 -- ---------------------------------------------------------------------------------------------------------------------------------

--- a/spe10/SPE10-MOD01-02.DATA
+++ b/spe10/SPE10-MOD01-02.DATA
@@ -79,9 +79,9 @@ REGDIMS
 GRIDOPTS
          NO       1*      1*                                                   /
 --
---       DEACTIVATES NON-NEIGHBOR CONNECTIONS
+--       DEACTIVATES NON-NEIGHBOR CONNECTIONS (NOT SUPPORTED)
 --
-NONNC
+--       NONNC
 -- ---------------------------------------------------------------------------------------------------------------------------------
 -- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS
 -- ---------------------------------------------------------------------------------------------------------------------------------

--- a/spe10/SPE10-MOD01-03.DATA
+++ b/spe10/SPE10-MOD01-03.DATA
@@ -83,9 +83,9 @@ REGDIMS
 GRIDOPTS
          NO       1*      1*                                                   /
 --
---       DEACTIVATES NON-NEIGHBOR CONNECTIONS
+--       DEACTIVATES NON-NEIGHBOR CONNECTIONS (NOT SUPPORTED)
 --
-NONNC
+--       NONNC
 -- ---------------------------------------------------------------------------------------------------------------------------------
 -- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS
 -- ---------------------------------------------------------------------------------------------------------------------------------

--- a/spe10/SPE10-MOD01-04.DATA
+++ b/spe10/SPE10-MOD01-04.DATA
@@ -79,9 +79,9 @@ REGDIMS
 GRIDOPTS
          NO       1*      1*                                                   /
 --
---       DEACTIVATES NON-NEIGHBOR CONNECTIONS
+--       DEACTIVATES NON-NEIGHBOR CONNECTIONS (NOT SUPPORTED)
 --
-NONNC
+--       NONNC
 -- ---------------------------------------------------------------------------------------------------------------------------------
 -- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS
 -- ---------------------------------------------------------------------------------------------------------------------------------

--- a/spe10/SPE10-MOD02-01.DATA
+++ b/spe10/SPE10-MOD02-01.DATA
@@ -101,9 +101,9 @@ EQLDIMS
 GRIDOPTS
          NO       1*      1*                                                   /
 --
---       DEACTIVATES NON-NEIGHBOR CONNECTIONS
+--       DEACTIVATES NON-NEIGHBOR CONNECTIONS (NOT SUPPORTED)
 --
-NONNC
+--       NONNC
 -- ---------------------------------------------------------------------------------------------------------------------------------
 -- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS
 -- ---------------------------------------------------------------------------------------------------------------------------------

--- a/spe10/SPE10-MOD02-02.DATA
+++ b/spe10/SPE10-MOD02-02.DATA
@@ -97,9 +97,9 @@ EQLDIMS
 GRIDOPTS
          NO       1*      1*                                                   /
 --
---       DEACTIVATES NON-NEIGHBOR CONNECTIONS
+--       DEACTIVATES NON-NEIGHBOR CONNECTIONS (NOT SUPPORTED)
 --
-NONNC
+--       NONNC
 -- ---------------------------------------------------------------------------------------------------------------------------------
 -- ROCK AND SATURATION TABLES DIMENSIONS AND OPTIONS
 -- ---------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Comment out the NONNC keyword in SPE10 cases, as the keyword is not supported, and results in the cases not running.