### PR TITLE
Disable PBUB/PDEW Output

### DIFF
--- a/aquifer-num/3D_2AQU_NUM.DATA
+++ b/aquifer-num/3D_2AQU_NUM.DATA
@@ -160,7 +160,7 @@ SOLUTION
 
 
 RPTRST
-  'BASIC = 2' 'PBPD' 'FIP' /
+  'BASIC = 2' 'FIP' /
 
 EQUIL
 -- Datum    P     woc       Pc   goc     Pc  Rsvd  Rvvd


### PR DESCRIPTION
This is hopefully a temporary measure, but we get a blocking issue preventing a desired realignment of the 3D solution array tags.  We will attempt to restore the output arrays at a later time.