### PR TITLE
Fixed data decks with GCONPROD item 7 not set to RATE

### DIFF
--- a/actionx/ACTIONX_GCONPROD.DATA
+++ b/actionx/ACTIONX_GCONPROD.DATA
@@ -360,7 +360,7 @@ GRUPTREE
 -- GRUP  CNTL  OIL    WAT    GAS    LIQ    CNTL  GRUP  GUIDE  GUIDE  CNTL
 -- NAME  MODE  RATE   RATE   RATE   RATE   OPT   CNTL  RATE   DEF    WAT
 GCONPROD
-FIELD    GRAT  1*     1*    275E3   1*     1*     1*    1*     1*     1*      /
+FIELD    GRAT  1*     1*    275E3   1*     RATE   1*    1*     1*     1*      /
 /
 --
 --       WELL SPECIFICATION DATA
@@ -494,7 +494,7 @@ ACTIONX
 -- GRUP  CNTL  OIL    WAT    GAS    LIQ    CNTL  GRUP  GUIDE  GUIDE  CNTL
 -- NAME  MODE  RATE   RATE   RATE   RATE   OPT   CNTL  RATE   DEF    WAT
 GCONPROD
-FIELD    GRAT  1*     1*    250E3   1*     1*     1*    1*     1*     1*      /
+FIELD    GRAT  1*     1*    250E3   1*     RATE   1*    1*     1*     1*      /
 /
 
 ENDACTIO
@@ -511,7 +511,7 @@ ACTIONX
 -- GRUP  CNTL  OIL    WAT    GAS    LIQ    CNTL  GRUP  GUIDE  GUIDE  CNTL
 -- NAME  MODE  RATE   RATE   RATE   RATE   OPT   CNTL  RATE   DEF    WAT
 GCONPROD
-FIELD    GRAT  1*     1*  FU_FGPR   1*     1*     1*    1*     1*     1*      /
+FIELD    GRAT  1*     1*  FU_FGPR   1*     RATE   1*    1*     1*     1*      /
 /
 
 ENDACTIO
@@ -528,7 +528,7 @@ ACTIONX
 -- GRUP  CNTL  OIL    WAT    GAS    LIQ    CNTL  GRUP  GUIDE  GUIDE  CNTL
 -- NAME  MODE  RATE   RATE   RATE   RATE   OPT   CNTL  RATE   DEF    WAT
 GCONPROD
-FIELD    GRAT  1*     1*     275E3  1*     1*     1*    1*     1*     1*      /
+FIELD    GRAT  1*     1*     275E3  1*     RATE   1*    1*     1*     1*      /
 /
 --
 --       WELL PRODUCTION WELL CONTROLS

--- a/spe9group/SPE9_CP_GROUP.DATA
+++ b/spe9group/SPE9_CP_GROUP.DATA
@@ -528,7 +528,7 @@ WCONPROD
 -- The total rates is set to 1500 STBO 
 GCONPROD
 --      oil   water  gas
-   'F'    'LRAT'  3* 1500 /
+   'F'    'LRAT'  3* 1500  'RATE' /
    'A'    'FLD'   4* 'RATE' 'YES' 1 'OIL' /
 /
 

--- a/spe9group/SPE9_CP_GROUP_RESV.DATA
+++ b/spe9group/SPE9_CP_GROUP_RESV.DATA
@@ -524,7 +524,7 @@ WCONPROD
 
 GCONPROD
 --      oil   water  gas
-   'F'    'RESV'  4* NONE NO 5* 1000 /
+   'F'    'RESV'  4* 'RATE'  NO 5* 1000 /
    'A'    'FLD'   4* 'RATE' 'YES' 1 'OIL' /
 /
 


### PR DESCRIPTION
Only RATE is supported in GCONPROD item 7. Notice that NONE is default, hence default not supported.

The current behavior of OPM Flow is that the simulator will handle item 7 input in GCONPROD as if this was RATE, independent of what the input actually is. Hence simulation results (all summary vectors and solution data in restart file ) will not changed due to this PR. However, this will modify output to some of the restart arrays (example IGRP). An update of reference solutions are therefor required. 

This is a preparation for a PR in opm-simulators which will stop the simulation if input different that RATE is given.  