### PR TITLE
Fix group name in WELSPECS

### DIFF
--- a/cskin/CSKIN-02.DATA
+++ b/cskin/CSKIN-02.DATA
@@ -246,7 +246,7 @@ TUNING
 -- WELL  GROUP        BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT    HYDS  FIP
 -- NAME  NAME   I  J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE  DENS  REGN
 WELSPECS
-   D-1H  1*     2  1  1*     OIL    0.0    STD     STOP  YES    0      SEG   0    /
+   D-1H  'TEST'  2  1  1*     OIL    0.0    STD     STOP  YES    0      SEG   0    /
 /
 
 -- WELL                     OPEN   SAT   CONN     WELL    KH     SKIN   D     DIR  Ro

--- a/cskin/CSKIN-03.DATA
+++ b/cskin/CSKIN-03.DATA
@@ -253,7 +253,7 @@ TUNING
 -- WELL  GROUP        BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT    HYDS  FIP
 -- NAME  NAME   I  J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE  DENS  REGN
 WELSPECS
-   D-1H  1*     2  1  1*     OIL    0.0    STD     STOP  YES    0      SEG   0    /
+   D-1H  'TEST' 2  1  1*     OIL    0.0    STD     STOP  YES    0      SEG   0    /
 /
 
 -- WELL                     OPEN   SAT   CONN     WELL    KH     SKIN   D     DIR  Ro

--- a/cskin/CSKIN-04.DATA
+++ b/cskin/CSKIN-04.DATA
@@ -250,7 +250,7 @@ TUNING
 -- WELL  GROUP        BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT    HYDS  FIP
 -- NAME  NAME   I  J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE  DENS  REGN
 WELSPECS
-   D-1H  1*     2  1  1*     OIL    0.0    STD     STOP  YES    0      SEG   0    /
+   D-1H  'TEST' 2  1  1*     OIL    0.0    STD     STOP  YES    0      SEG   0    /
 /
 
 -- WELL                     OPEN   SAT   CONN     WELL   KH     SKIN   D     DIR  Ro

--- a/cskin/CSKIN-05.DATA
+++ b/cskin/CSKIN-05.DATA
@@ -251,7 +251,7 @@ TUNING
 -- WELL  GROUP        BHP    PHASE  DRAIN  INFLOW  OPEN  CROSS  PVT    HYDS  FIP
 -- NAME  NAME   I  J  DEPTH  FLUID  AREA   EQUANS  SHUT  FLOW   TABLE  DENS  REGN
 WELSPECS
-   D-1H  1*     2  1  1*     OIL    0.0    STD     STOP  YES    0      SEG   0    /
+   D-1H  'TEST' 2  1  1*     OIL    0.0    STD     STOP  YES    0      SEG   0    /
 /
 
 -- WELL                     OPEN   SAT   CONN    WELL   KH     SKIN   D     DIR  Ro


### PR DESCRIPTION
The default group name gave errors in OPM Flow.

Related to opm-common and opm-simulators PRs: https://github.com/OPM/opm-common/pull/3681 and https://github.com/OPM/opm-simulators/pull/4871