### PR TITLE
fix illegal spaces in WELSPECS keyword

### DIFF
--- a/welspecs/TEST3_WS.DATA
+++ b/welspecs/TEST3_WS.DATA
@@ -313,7 +313,7 @@ DATES
 
 WELSPECS
 --WELL   GROUP  
- '*'  '  B1'    /
+ '*'  'B1'    /
 /
 
 


### PR DESCRIPTION
Updated test case with extended `WELSPECS`. Illegal spaces in item number 2 in keyword `WELSPEC` gives error message
```
Error: Problem with keyword WELSPECS
In TEST3_WS.DATA line 314
Illegal space in   B1 when defining WELL/GROUP.
```