### PR TITLE
Add Test Case for Summary Vectors With Short Region Set Names

### DIFF
--- a/regset/SPE1CASE2_REGSET.DATA
+++ b/regset/SPE1CASE2_REGSET.DATA
@@ -1,0 +1,263 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2015--2023 Equinor ASA
+
+-- This deck tests usage of region level summary vector names
+-- referring to user-defined region sets, with the vector names using
+-- only a unique prefix of the full region set name.
+
+RUNSPEC
+-- -------------------------------------------------------------------------
+
+TITLE
+   SPE1 - CASE 2 Short Region Set Names
+
+DIMENS
+   10 10 3 /
+
+EQLDIMS
+/
+
+TABDIMS
+/
+
+OIL
+GAS
+WATER
+DISGAS
+
+FIELD
+
+START
+   11 'DEC' 2023 /
+
+WELLDIMS
+-- Item 1: maximum number of wells in the model
+-- Item 2: maximum number of grid blocks connected to any one well
+-- Item 3: maximum number of groups in the model
+-- Item 4: maximum number of wells in any one group
+   2 1 1 2 /
+
+UNIFIN
+UNIFOUT
+
+GRID
+
+INIT
+
+-- -------------------------------------------------------------------------
+NOECHO
+
+DX
+-- There are in total 300 cells with length 1000ft in x-direction
+        300*1000 /
+DY
+-- There are in total 300 cells with length 1000ft in y-direction
+        300*1000 /
+DZ
+-- The layers are 20, 30 and 50 ft thick, in each layer there are 100 cells
+        100*20 100*30 100*50 /
+
+TOPS
+-- The depth of the top of each grid block
+        100*8325 /
+
+PORO
+-- Constant porosity of 0.3 throughout all 300 grid cells
+        300*0.3 /
+
+PERMX
+-- The layers have perm. 500mD, 50mD and 200mD, respectively.
+        100*500 100*50 100*200 /
+
+PERMY
+        100*500 100*50 100*200 /
+
+PERMZ
+        100*500 100*50 100*200 /
+ECHO
+
+PROPS
+-- -------------------------------------------------------------------------
+
+PVTW
+-- Item 1: pressure reference (psia)
+-- Item 2: water FVF (rb per bbl or rb per stb)
+-- Item 3: water compressibility (psi^{-1})
+-- Item 4: water viscosity (cp)
+-- Item 5: water 'viscosibility' (psi^{-1})
+
+-- Using values from Norne:
+-- In METRIC units:
+--      277.0 1.038 4.67E-5 0.318 0.0 /
+-- In FIELD units:
+        4017.55 1.038 3.22E-6 0.318 0.0 /
+
+ROCK
+-- Item 1: reference pressure (psia)
+-- Item 2: rock compressibility (psi^{-1})
+        14.7 3E-6 /
+
+SWOF
+-- Column 1: water saturation
+-- Column 2: water relative permeability
+-- Column 3: oil relative permeability when only oil and water are present
+-- Column 4: corresponding water-oil capillary pressure (psi)
+
+0.12	0                       1	0
+0.18	4.64876033057851E-008	1	0
+0.24	0.000000186		0.997	0
+0.3	4.18388429752066E-007	0.98	0
+0.36	7.43801652892562E-007	0.7	0
+0.42	1.16219008264463E-006	0.35	0
+0.48	1.67355371900826E-006	0.2	0
+0.54	2.27789256198347E-006	0.09	0
+0.6	2.97520661157025E-006	0.021	0
+0.66	3.7654958677686E-006	0.01	0
+0.72	4.64876033057851E-006	0.001	0
+0.78	0.000005625		0.0001	0
+0.84	6.69421487603306E-006	0	0
+0.91	8.05914256198347E-006	0	0
+1	0.00001			0	0 /
+
+
+SGOF
+-- Column 1: gas saturation
+-- Column 2: gas relative permeability
+-- Column 3: oil relative permeability when oil, gas and connate water are present
+-- Column 4: oil-gas capillary pressure (psi)
+0	0	1	0
+0.001	0	1	0
+0.02	0	0.997	0
+0.05	0.005	0.980	0
+0.12	0.025	0.700	0
+0.2	0.075	0.350	0
+0.25	0.125	0.200	0
+0.3	0.190	0.090	0
+0.4	0.410	0.021	0
+0.45	0.60	0.010	0
+0.5	0.72	0.001	0
+0.6	0.87	0.0001	0
+0.7	0.94	0.000	0
+0.85	0.98	0.000	0
+0.88	0.984	0.000	0 /
+--1.00	1.0	0.000	0 /
+
+DENSITY
+-- Density (lb per ft³) at surface cond. of
+-- oil, water and gas, respectively (in that order)
+
+-- Using values from Norne:
+-- In METRIC units:
+--      859.5 1033.0 0.854 /
+-- In FIELD units:
+        53.66 64.49 0.0533 /
+
+PVDG
+-- Column 1: gas phase pressure (psia)
+-- Column 2: gas formation volume factor (rb per Mscf)
+-- Column 3: gas viscosity (cP)
+
+14.700	166.666	0.008000
+264.70	12.0930	0.009600
+514.70	6.27400	0.011200
+1014.7	3.19700	0.014000
+2014.7	1.61400	0.018900
+2514.7	1.29400	0.020800
+3014.7	1.08000	0.022800
+4014.7	0.81100	0.026800
+5014.7	0.64900	0.030900
+9014.7	0.38600	0.047000 /
+
+PVTO
+-- Column 1: dissolved gas-oil ratio (Mscf per stb)
+-- Column 2: bubble point pressure (psia)
+-- Column 3: oil FVF for saturated oil (rb per stb)
+-- Column 4: oil viscosity for saturated oil (cP)
+
+0.0010	14.7	1.0620	1.0400 /
+0.0905	264.7	1.1500	0.9750 /
+0.1800	514.7	1.2070	0.9100 /
+0.3710	1014.7	1.2950	0.8300 /
+0.6360	2014.7	1.4350	0.6950 /
+0.7750	2514.7	1.5000	0.6410 /
+0.9300	3014.7	1.5650	0.5940 /
+1.2700	4014.7	1.6950	0.5100
+        9014.7	1.5790	0.7400 /
+1.6180	5014.7	1.8270	0.4490
+        9014.7	1.7370	0.6310 /
+/
+
+REGIONS
+
+FIPABCDE
+  100*1
+  100*2
+  100*3 /
+
+SOLUTION
+-- -------------------------------------------------------------------------
+
+EQUIL
+-- Item 1: datum depth (ft)
+-- Item 2: pressure at datum depth (psia)
+-- Item 3: depth of water-oil contact (ft)
+-- Item 4: oil-water capillary pressure at the water oil contact (psi)
+-- Item 5: depth of gas-oil contact (ft)
+-- Item 6: gas-oil capillary pressure at gas-oil contact (psi)
+-- Item 7: RSVD-table
+-- Item 8: RVVD-table
+-- Item 9: Equilibration method--0 is centre point.
+
+-- Item #: 1 2    3    4 5    6 7 8 9
+        8400 4800 8450 0 8300 0 1 0 0 /
+
+RSVD
+-- Dissolved GOR is initially constant with depth through the reservoir.
+-- The reason is that the initial reservoir pressure given is higher
+---than the bubble point presssure of 4014.7psia, meaning that there is no
+-- free gas initially present.
+8300 1.270
+8450 1.270 /
+
+SUMMARY
+-- -------------------------------------------------------------------------
+
+ROIP_ABC
+/
+
+SCHEDULE
+-- -------------------------------------------------------------------------
+
+RPTRST
+ 'BASIC=2' /
+
+WELSPECS
+-- Item #: 1	 2	3	4	5	 6
+        'PROD'	'G1'	10	10	8400	'OIL' /
+        'INJ'	'G1'	1	1	8335	'GAS' /
+/
+
+COMPDAT
+-- Item #: 1	2	3	4	5	6	7	8	9
+        'PROD'	10	10	3	3	'OPEN'	1*	1*	0.5 /
+        'INJ'	1	1	1	1	'OPEN'	1*	1*	0.5 /
+/
+
+WCONPROD
+-- Item #:1	2      3     4	   5  9
+        'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
+/
+
+WCONINJE
+-- Item #:1	 2	 3	 4	5      6  7
+        'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
+/
+
+TSTEP
+5*30 /
+
+END


### PR DESCRIPTION
Mostly to keep cases with "long" region set names like
```
FIPABCDE
```
working alongside summary vector names of the form
```
ROIP_ABC
```