### PR TITLE
changed: remove CONV from RST output

### DIFF
--- a/model4/MOD4_GRP.DATA
+++ b/model4/MOD4_GRP.DATA
@@ -228,7 +228,7 @@ RSVD
 
 -- basic = 5, every month
 RPTRST
- 'BASIC=5'  'FREQ=6'   'CONV=10' /
+ 'BASIC=5'  'FREQ=6'    /
 
 RPTSOL
  'RESTART=2'  'FIP=3'  'FIPRESV'  'THPRES' /

--- a/model4/MOD4_GRP_GEFAC.DATA
+++ b/model4/MOD4_GRP_GEFAC.DATA
@@ -231,7 +231,7 @@ RSVD
 
 -- basic = 5, every month
 RPTRST
- 'BASIC=5'  'FREQ=6'   'CONV=10' /
+ 'BASIC=5'  'FREQ=6'   /
 
 RPTSOL
  'RESTART=2'  'FIP=3'  'FIPRESV'  'THPRES' /

--- a/model4/MOD4_GRP_INPLACE_RESTART.DATA
+++ b/model4/MOD4_GRP_INPLACE_RESTART.DATA
@@ -225,7 +225,7 @@ RSVD
 
 -- basic = 5, every month
 RPTRST
- 'BASIC=5'  'FREQ=6'   'CONV=10' /
+ 'BASIC=5'  'FREQ=6'   /
 
 RPTSOL
  'RESTART=2'  'FIP=3'  'FIPRESV'  'THPRES' /

--- a/model4/MOD4_GRP_RESTART.DATA
+++ b/model4/MOD4_GRP_RESTART.DATA
@@ -225,7 +225,7 @@ RSVD
 
 -- basic = 5, every month
 RPTRST
- 'BASIC=5'  'FREQ=6'   'CONV=10' /
+ 'BASIC=5'  'FREQ=6'   /
 
 RPTSOL
  'RESTART=2'  'FIP=3'  'FIPRESV'  'THPRES' /

--- a/model4/MOD4_UDQ_ACTIONX.DATA
+++ b/model4/MOD4_UDQ_ACTIONX.DATA
@@ -257,7 +257,7 @@ RSVD
 
 -- basic = 5, every month
 RPTRST
- 'BASIC=5'  'FREQ=6'   'CONV=10' /
+ 'BASIC=5'  'FREQ=6'   /
 
 RPTSOL
  'RESTART=2'  'FIP=3'  'FIPRESV'  'THPRES' /


### PR DESCRIPTION
With this implemented, we want to remove the potential source of instability in regression tests.

Sidestream of https://github.com/OPM/opm-simulators/pull/5054