### PR TITLE
Remove actionx_callback

### DIFF
--- a/udq_actionx/udq.py
+++ b/udq_actionx/udq.py
@@ -5,7 +5,7 @@
 #   DEFINE WULPRU (WLPR OPU01 - 300) * 0.80 /
 # /
 
-def run(ecl_state, schedule, report_step, summary_state, actionx_callback):
+def run(ecl_state, schedule, report_step, summary_state):
     for udq,var,src_well,target_well, shift,factor in [("WUOPRL", "WOPR", "OPL01", "OPL02", 150, 0.90),
                                                        ("WULPRL", "WLPR", "OPL01", "OPL02", 200, 0.90),
                                                        ("WUOPRU", "WOPR", "OPU01", "OPU02", 250, 0.80),


### PR DESCRIPTION
In https://github.com/OPM/opm-common/pull/3948, I've removed the actionx_callback, this PR removes it in opm-tests as well.