### PR TITLE
Add a test to illustrate ACTNUM with CARFIN

### DIFF
--- a/lgr/SPE1CASE1_CARFIN_XY_ACTNUM.DATA
+++ b/lgr/SPE1CASE1_CARFIN_XY_ACTNUM.DATA
@@ -1,0 +1,526 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2021 Equinor
+
+-- This simulation is based on the data given in 
+-- 'Comparison of Solutions to a Three-Dimensional
+-- Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+-- Journal of Petroleum Technology, January 1981
+
+-- The purpose of this data set is to be a test for LGR grid.
+-- In particular CARFIN and ENDFIN keyword are used.
+-- Wells are located in the coarse grid
+
+
+
+---------------------------------------------------------------------------
+------------------------ SPE1 - CASE 1 ------------------------------------
+---------------------------------------------------------------------------
+
+RUNSPEC
+-- -------------------------------------------------------------------------
+
+TITLE
+   SPE1 - CASE 1
+
+DIMENS
+   10 1 1 /
+   
+-- The number of equilibration regions is inferred from the EQLDIMS
+-- keyword.
+EQLDIMS
+/
+
+-- The number of PVTW tables is inferred from the TABDIMS keyword;
+-- when no data is included in the keyword the default values are used.
+TABDIMS
+/
+NSTACK
+25 /
+OIL
+GAS
+WATER
+DISGAS
+-- As seen from figure 4 in Odeh, GOR is increasing with time,
+-- which means that dissolved gas is present
+
+FIELD
+LGR
+      1         400          0    0    0   10   /
+--NOINTERPINTERP
+START
+   1 'JAN' 2015 /
+
+WELLDIMS
+-- Item 1: maximum number of wells in the model
+-- 	   - there are two wells in the problem; injector and producer
+-- Item 2: maximum number of grid blocks connected to any one well
+-- 	   - must be one as the wells are located at specific grid blocks
+-- Item 3: maximum number of groups in the model
+-- 	   - we are dealing with only one 'group'
+-- Item 4: maximum number of wells in any one group
+-- 	   - there must be two wells in a group as there are two wells in total
+   2 1 1 2 /
+
+UNIFOUT
+
+GRID
+NEWTRAN
+RPTGRID
+  -- Report Levels for Grid Section Data
+  -- 
+  'DX' 
+  'DY' 
+  'DZ' 
+  'PERMX' 
+  'PERMY' 
+  'PERMZ' 
+  'MULTX' 
+  'MULTY' 
+  'MULTZ' 
+  'PORO' 
+  'NTG' 
+  'TOPS' 
+  'PORV' 
+  'DEPTH' 
+  'TRANX' 
+  'TRANY' 
+  'TRANZ' 
+   / 
+
+RPTGRIDL
+  -- Report Levels for Grid Section Data
+  -- 
+  'DX' 
+  'DY' 
+  'DZ' 
+  'PERMX' 
+  'PERMY' 
+  'PERMZ' 
+  'MULTX' 
+  'MULTY' 
+  'MULTZ' 
+  'PORO' 
+  'NTG' 
+  'TOPS' 
+  'PORV' 
+  'DEPTH' 
+  'TRANX' 
+  'TRANY' 
+  'TRANZ' 
+   / 
+CARFIN
+-- NAME I1-I2 J1-J2 K1-K2 NX NY NZ
+'LGR1'  5  7  1  1  1  1  9  2  1 /
+ENDFIN
+
+RPTGRIDL
+COORD TRANX TRANY TRANZ MULTX MULTY MULTZ ALLNNC /
+-- The INIT keyword is used to request an .INIT file. The .INIT file
+-- is written before the simulation actually starts, and contains grid
+-- properties and saturation tables as inferred from the input
+-- deck. There are no other keywords which can be used to configure
+-- exactly what is written to the .INIT file.
+INIT
+
+
+-- -------------------------------------------------------------------------
+--DX 
+-- There are in total 300 cells with length 1000ft in x-direction	
+--   	10*1000 /
+--DY
+-- There are in total 300 cells with length 1000ft in y-direction	
+--	10*1000 /
+--DZ
+-- The layers are 20, 30 and 50 ft thick, in each layer there are 100 cells
+--100*50 100*50 100*50 /
+--10*20  /
+
+--TOPS
+-- The depth of the top of each grid block
+--	10*8325 /
+COORD
+    0    0 8300     0    0 8500
+1000    0 8300  1000    0 8500
+2000    0 8300  2000    0 8500
+3000    0 8300  3000    0 8500
+4000    0 8300  4000    0 8500
+5000    0 8300  5000    0 8500
+6000    0 8300  6000    0 8500
+7000    0 8300  7000    0 8500
+8000    0 8300  8000    0 8500
+9000    0 8300  9000    0 8500
+10000    0 8300 10000    0 8500
+    0 1000 8300     0 1000 8500
+1000 1000 8300  1000 1000 8500
+2000 1000 8300  2000 1000 8500
+3000 1000 8300  3000 1000 8500
+4000 1000 8300  4000 1000 8500
+5000 1000 8300  5000 1000 8500
+6000 1000 8300  6000 1000 8500
+7000 1000 8300  7000 1000 8500
+8000 1000 8300  8000 1000 8500
+9000 1000 8300  9000 1000 8500
+10000 1000 8300 10000 1000 8500
+/
+
+ZCORN
+8325 8345 8345 8375 8375 8415 8415 8445 8445 8465 8465 8475 8475 8465 8465 8445 8445 8415 8415 8375
+8325 8345 8345 8375 8375 8415 8415 8445 8445 8465 8465 8475 8475 8465 8465 8445 8445 8415 8415 8375
+
+8345 8365 8365 8405 8405 8455 8455 8465 8465 8475 8475 8485 8485 8485 8485 8475 8475 8455 8455 8425
+8345 8365 8365 8405 8405 8455 8455 8465 8465 8475 8475 8485 8485 8485 8485 8475 8475 8455 8455 8425
+/ 
+
+ACTNUM
+1 0 1 1 1 0 1 0 1 1
+/
+PORO
+-- Constant porosity of 0.3 throughout all 300 grid cells
+   	10*0.3 /
+
+PERMX
+-- The layers have perm. 500mD, 50mD and 200mD, respectively.
+	10*500  /
+
+PERMY
+-- Equal to PERMX
+	10*500 /
+
+PERMZ
+-- Cannot find perm. in z-direction in Odeh's paper
+-- For the time being, we will assume PERMZ equal to PERMX and PERMY:
+	10*500  /
+ECHO
+
+PROPS
+-- -------------------------------------------------------------------------
+
+PVTW
+-- Item 1: pressure reference (psia)
+-- Item 2: water FVF (rb per bbl or rb per stb)
+-- Item 3: water compressibility (psi^{-1})
+-- Item 4: water viscosity (cp)
+-- Item 5: water 'viscosibility' (psi^{-1})
+
+-- Using values from Norne:
+-- In METRIC units:
+-- 	277.0 1.038 4.67E-5 0.318 0.0 /
+-- In FIELD units:
+    	4017.55 1.038 3.22E-6 0.318 0.0 /
+
+ROCK
+-- Item 1: reference pressure (psia)
+-- Item 2: rock compressibility (psi^{-1})
+
+-- Using values from table 1 in Odeh:
+	14.7 3E-6 /
+
+SWOF
+-- Column 1: water saturation
+--   	     - this has been set to (almost) equally spaced values from 0.12 to 1
+-- Column 2: water relative permeability
+--   	     - generated from the Corey-type approx. formula
+--	       the coeffisient is set to 10e-5, S_{orw}=0 and S_{wi}=0.12
+-- Column 3: oil relative permeability when only oil and water are present
+--	     - we will use the same values as in column 3 in SGOF.
+-- 	       This is not really correct, but since only the first 
+--	       two values are of importance, this does not really matter
+-- Column 4: water-oil capillary pressure (psi) 
+
+0.22	0	1	0
+0.3	0.07	0.4	0
+0.4	0.15	0.125	0
+0.5	0.24	0.0649	0
+0.6	0.33	0.0048	0
+0.8	0.65	0	0
+0.9	0.83	0	0
+1	1	0	0 /
+
+
+SGOF
+-- Column 1: gas saturation
+-- Column 2: gas relative permeability
+-- Column 3: oil relative permeability when oil, gas and connate water are present
+-- Column 4: oil-gas capillary pressure (psi)
+-- 	     - stated to be zero in Odeh's paper
+
+-- Values in column 1-3 are taken from table 3 in Odeh's paper:
+0	0	1	0
+0.04	0	0.6	0
+0.1	0.022	0.33	0
+0.2	0.1	0.1	0
+0.3	0.24	0.02	0
+0.4	0.34	0	0
+0.5	0.42	0	0
+0.6	0.5	0	0
+0.7	0.8125	0	0
+0.78	1	0	0 /
+--1.00	1.0	0.000	0 /
+-- Warning from Eclipse: first sat. value in SWOF + last sat. value in SGOF
+-- 	   		 must not be greater than 1, but Eclipse still runs
+-- Flow needs the sum to be excactly 1 so I added a row with gas sat. =  0.88
+-- The corresponding krg value was estimated by assuming linear rel. between
+-- gas sat. and krw. between gas sat. 0.85 and 1.00 (the last two values given)
+
+DENSITY
+-- Density (lb per ft³) at surface cond. of 
+-- oil, water and gas, respectively (in that order)
+
+-- Using values from Norne:
+-- In METRIC units:
+--      859.5 1033.0 0.854 /
+-- In FIELD units:
+      	53.66 64.49 0.0533 /
+
+PVDG
+-- Column 1: gas phase pressure (psia)
+-- Column 2: gas formation volume factor (rb per Mscf)
+-- 	     - in Odeh's paper the units are said to be given in rb per bbl, 
+-- 	       but this is assumed to be a mistake: FVF-values in Odeh's paper 
+--	       are given in rb per scf, not rb per bbl. This will be in 
+--	       agreement with conventions
+-- Column 3: gas viscosity (cP)
+
+-- Using values from lower right table in Odeh's table 2:
+14.700	166.666	0.008000
+264.70	12.0930	0.009600
+514.70	6.27400	0.011200
+1014.7	3.19700	0.014000
+2014.7	1.61400	0.018900
+2514.7	1.29400	0.020800
+3014.7	1.08000	0.022800
+4014.7	0.81100	0.026800
+5014.7	0.64900	0.030900
+9014.7	0.38600	0.047000 /
+
+PVTO
+-- Column 1: dissolved gas-oil ratio (Mscf per stb)
+-- Column 2: bubble point pressure (psia)
+-- Column 3: oil FVF for saturated oil (rb per stb)
+-- Column 4: oil viscosity for saturated oil (cP)
+
+-- Use values from top left table in Odeh's table 2:
+0.0010	14.7	1.0620	1.0400 /
+0.0905	264.7	1.1500	0.9750 /
+0.1800	514.7	1.2070	0.9100 /
+0.3710	1014.7	1.2950	0.8300 /
+0.6360	2014.7	1.4350	0.6950 /
+0.7750	2514.7	1.5000	0.6410 /
+0.9300	3014.7	1.5650	0.5940 /
+1.2700	4014.7	1.6950	0.5100 
+        5014.7	1.6790	0.5200
+	    9014.7	1.6490	0.5400 /
+		/
+	
+		
+-- It is required to enter data for undersaturated oil for the highest GOR
+-- (i.e. the last row) in the PVTO table.
+-- In order to fulfill this requirement, values for oil FVF and viscosity
+-- at 9014.7psia and GOR=1.618 for undersaturated oil have been approximated:
+-- It has been assumed that there is a linear relation between the GOR
+-- and the FVF when keeping the pressure constant at 9014.7psia.
+-- From Odeh we know that (at 9014.7psia) the FVF is 2.357 at GOR=2.984
+-- for saturated oil and that the FVF is 1.579 at GOR=1.27 for undersaturated oil,
+-- so it is possible to use the assumption described above. 
+-- An equivalent approximation for the viscosity has been used.
+/
+
+SOLUTION
+-- -------------------------------------------------------------------------
+
+EQUIL
+-- Item 1: datum depth (ft)
+-- Item 2: pressure at datum depth (psia)
+-- 	   - Odeh's table 1 says that initial reservoir pressure is 
+-- 	     4800 psi at 8400ft, which explains choice of item 1 and 2
+-- Item 3: depth of water-oil contact (ft)
+-- 	   - chosen to be directly under the reservoir
+-- Item 4: oil-water capillary pressure at the water oil contact (psi)
+-- 	   - given to be 0 in Odeh's paper
+-- Item 5: depth of gas-oil contact (ft)
+-- 	   - chosen to be directly above the reservoir
+-- Item 6: gas-oil capillary pressure at gas-oil contact (psi)
+-- 	   - given to be 0 in Odeh's paper
+-- Item 7: RSVD-table
+-- Item 8: RVVD-table
+-- Item 9: Set to 0 as this is the only value supported by OPM
+
+-- Item #: 1 2    3    4 5    6 7 8 9
+	8400 5000 9850 0 2000 0 1 0 0 /
+
+RSVD
+-- Dissolved GOR is initially constant with depth through the reservoir.
+-- The reason is that the initial reservoir pressure given is higher 
+---than the bubble point presssure of 4014.7psia, meaning that there is no 
+-- free gas initially present.
+8300 1.270
+8450 1.270 /
+
+SUMMARY
+-- -------------------------------------------------------------------------	 
+
+-- 1a) Oil rate vs time
+FOPR
+-- Field Oil Production Rate
+FPR
+-- 1b) GOR vs time
+WGOR
+-- Well Gas-Oil Ratio
+   'PROD'
+/
+-- Using FGOR instead of WGOR:PROD results in the same graph
+FGOR
+
+-- 2a) Pressures of the cell where the injector and producer are located
+BPR
+1  1  1 /
+10 1 1 /
+/
+
+-- 2b) Gas saturation at grid points given in Odeh's paper
+BGSAT
+1  1  1 /
+10 1  1 /
+/
+
+-- In order to compare Eclipse with Flow:
+WBHP
+  'INJ'
+  'PROD'
+/
+WGIR
+  'INJ'
+  'PROD'
+/
+WGIT
+  'INJ'
+  'PROD'
+/
+WGPR
+  'INJ'
+  'PROD'
+/
+WGPT
+  'INJ'
+  'PROD'
+/
+WOIR
+  'INJ'
+  'PROD'
+/
+WOIT
+  'INJ'
+  'PROD'
+/
+WOPR
+  'INJ'
+  'PROD'
+/
+WOPT
+  'INJ'
+  'PROD'
+/
+WWIR
+  'INJ'
+  'PROD'
+/
+WWIT
+  'INJ'
+  'PROD'
+/
+WWPR
+  'INJ'
+  'PROD'
+/
+WWPT
+  'INJ'
+  'PROD'
+/
+SCHEDULE
+-- -------------------------------------------------------------------------
+RPTSCHED
+	'PRES' 'SGAS' 'RS' 'WELLS' /
+
+RPTRST
+	'BASIC=1' /
+
+
+-- If no resolution (i.e. case 1), the two following lines must be added:
+DRSDT
+0 /
+-- if DRSDT is set to 0, GOR cannot rise and free gas does not 
+-- dissolve in undersaturated oil -> constant bubble point pressure
+--TUNING                                  
+--0.01 0.1  /
+--/
+--/
+--TUNING
+-- 0.001  0.01 0.00001 0.1 1.5 0.01 3*/
+-- 1 0.5/
+-- /
+WELSPECS
+-- Item #: 1	 2	3	4	5	 6
+	'PROD'	'G1'	10	1	1*	'OIL' /
+	'INJ'	'G1'	1	1	1*	'WATER' /
+/
+-- Coordinates in item 3-4 are retrieved from Odeh's figure 1 and 2
+-- Note that the depth at the midpoint of the well grid blocks
+-- has been used as reference depth for bottom hole pressure in item 5
+
+COMPDAT
+-- Item #: 1	2	3	4	5	6	7	8	9
+	'PROD'	10	1	1	1	'OPEN'	1*	1*	0.5 /
+	'INJ'	1	1	1	1	'OPEN'	1*	1*	0.5 /
+/
+-- Coordinates in item 2-5 are retreived from Odeh's figure 1 and 2 
+-- Item 9 is the well bore internal diameter, 
+-- the radius is given to be 0.25ft in Odeh's paper
+
+WCONPROD
+-- Item #:1	2      3     4	   5  9
+	'PROD' 'SHUT' 'ORAT' 80000 4* 1000 /
+/
+-- It is stated in Odeh's paper that the maximum oil prod. rate
+-- is 20 000stb per day which explains the choice of value in item 4.
+-- The items > 4 are defaulted with the exception of item  9,
+-- the BHP lower limit, which is given to be 1000psia in Odeh's paper
+
+WCONINJE
+-- Item #:1	 2	 3	 4	5      6  7
+	'INJ'	'WATER'	'SHUT'	'RATE'	300000 1* 1* /
+/
+TSTEP
+2*1
+/
+
+WCONPROD
+-- Item #:1	2      3     4	   5  9
+	'PROD' 'OPEN' 'ORAT' 80000 4* 1000 /
+/
+-- It is stated in Odeh's paper that the maximum oil prod. rate
+-- is 20 000stb per day which explains the choice of value in item 4.
+-- The items > 4 are defaulted with the exception of item  9,
+-- the BHP lower limit, which is given to be 1000psia in Odeh's paper
+
+WCONINJE
+-- Item #:1	 2	 3	 4	5      6  7
+	'INJ'	'WATER'	'OPEN'	'RATE'	300000 1* 1* /
+/
+-- Stated in Odeh that gas inj. rate (item 5) is 100MMscf per day
+-- BHP upper limit (item 7) should not be exceeding the highest
+-- pressure in the PVT table=9014.7psia (default is 100 000psia)
+--LGROFF
+--'LGR1'/
+--LGROFF
+--'LGR2'/
+TSTEP
+--Advance the simulater once a month for ONE years:
+31*1 100*60 
+/
+
+
+END


### PR DESCRIPTION
This PR adds a test with the purpose of illustrating improvements on refinement in Corner Point grids. Precisely, the old-requirements of
- all the cells must be active, and
- only Cartesian grids,
are not necessary anymore. 

Attached 2 screenshots of the grid with all the cells active, and 2 with 3 inactive cells (one of them inside the LGR, the other 2 cells outside the LGR).

The improvements on the refinement for Corner Point grids related to inactive/active cells are in OPM/opm-grid#734. Additionally, global refinement is in OPM/opm-grid#732. Finally, refine a mixed grid (with coarse and refined cells), in OPM/opm-grid#731.