### PR TITLE
Keywords (OPTIONS and PIMULTAB) not supported were commented.

### DIFF
--- a/norne/NORNE_ATW2013.DATA
+++ b/norne/NORNE_ATW2013.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -96,8 +97,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -630,11 +631,10 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
---INCLUDE
---'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+----INCLUDE
+----'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 -- History
 INCLUDE
 './INCLUDE/BC0407_HIST01122006.SCH' / 
 
-END

--- a/norne/NORNE_ATW2013_1A_MSW.DATA
+++ b/norne/NORNE_ATW2013_1A_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -109,8 +110,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -121,8 +122,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -665,8 +666,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -678,4 +678,3 @@ INCLUDE
  './INCLUDE/PRED_DEPLETION_MIN_BHP_1A_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_1A_STDW.DATA
+++ b/norne/NORNE_ATW2013_1A_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -105,8 +106,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -117,8 +118,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -661,8 +662,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -674,4 +674,3 @@ INCLUDE
  './INCLUDE/PRED_DEPLETION_MIN_BHP_1A_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_1B_MSW.DATA
+++ b/norne/NORNE_ATW2013_1B_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -110,8 +111,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  150 /
@@ -122,8 +123,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -675,8 +676,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -688,4 +688,3 @@ INCLUDE
  './INCLUDE/PRED_DEPLETION_MIN_THP_1B_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_1B_MSW_NO_XFLOW.DATA
+++ b/norne/NORNE_ATW2013_1B_MSW_NO_XFLOW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -110,8 +111,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  150 /
@@ -122,8 +123,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -675,8 +676,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -688,4 +688,3 @@ INCLUDE
  './INCLUDE/PRED_DEPLETION_MIN_THP_1B_MSW_NO_XFLOW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_1B_STDW.DATA
+++ b/norne/NORNE_ATW2013_1B_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -105,8 +106,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -117,8 +118,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -661,8 +662,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -674,4 +674,3 @@ INCLUDE
  './INCLUDE/PRED_DEPLETION_MIN_THP_1B_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_2A_MSW.DATA
+++ b/norne/NORNE_ATW2013_2A_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -111,8 +112,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -123,8 +124,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -670,8 +671,8 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--INCLUDE
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -687,4 +688,3 @@ INCLUDE
  './INCLUDE/PRED_DEPLETION_MIN_THP_2A_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_2A_STDW.DATA
+++ b/norne/NORNE_ATW2013_2A_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -106,8 +107,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -118,8 +119,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -661,8 +662,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -678,4 +678,3 @@ INCLUDE
  './INCLUDE/PRED_DEPLETION_MIN_THP_2A_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_2B_MSW.DATA
+++ b/norne/NORNE_ATW2013_2B_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -112,8 +113,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -124,8 +125,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -670,8 +671,8 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--INCLUDE
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 
@@ -699,4 +700,3 @@ INCLUDE
  './INCLUDE/PRED_DEPLETION_MIN_THP_2B_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_2B_STDW.DATA
+++ b/norne/NORNE_ATW2013_2B_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -108,8 +109,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -120,8 +121,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -664,8 +665,8 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--INCLUDE
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 
@@ -693,4 +694,3 @@ INCLUDE
  './INCLUDE/PRED_DEPLETION_MIN_THP_2B_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_3A_MSW.DATA
+++ b/norne/NORNE_ATW2013_3A_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -112,8 +113,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -124,8 +125,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -672,8 +673,8 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--INCLUDE
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -694,4 +695,3 @@ INCLUDE
  './INCLUDE/PRED_GINJ_MIN_THP_3A_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_3A_STDW.DATA
+++ b/norne/NORNE_ATW2013_3A_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -106,8 +107,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -118,8 +119,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -662,8 +663,8 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--INCLUDE
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -684,4 +685,3 @@ INCLUDE
  './INCLUDE/PRED_GINJ_MIN_THP_3A_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_3B_MSW.DATA
+++ b/norne/NORNE_ATW2013_3B_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -110,8 +111,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -122,8 +123,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -666,8 +667,8 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--INCLUDE
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -688,4 +689,3 @@ INCLUDE
  './INCLUDE/PRED_GINJ_MIN_THP_3B_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_3B_STDW.DATA
+++ b/norne/NORNE_ATW2013_3B_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -107,8 +108,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -119,8 +120,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -667,8 +668,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -689,4 +689,3 @@ INCLUDE
  './INCLUDE/PRED_GINJ_MIN_THP_3B_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_3C_MSW.DATA
+++ b/norne/NORNE_ATW2013_3C_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -111,8 +112,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -123,8 +124,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -671,8 +672,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -696,4 +696,3 @@ INCLUDE
  './INCLUDE/PRED_GINJ_MIN_THP_3B_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_3C_STDW.DATA
+++ b/norne/NORNE_ATW2013_3C_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -107,8 +108,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -119,8 +120,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -663,8 +664,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -688,4 +688,3 @@ INCLUDE
  './INCLUDE/PRED_GINJ_MIN_THP_3B_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_4A_MSW.DATA
+++ b/norne/NORNE_ATW2013_4A_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -109,8 +110,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -121,8 +122,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -668,8 +669,8 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--INCLUDE
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -686,4 +687,3 @@ INCLUDE
  './INCLUDE/PRED_WINJ_MIN_THP_4A_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_4A_STDW.DATA
+++ b/norne/NORNE_ATW2013_4A_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -103,8 +104,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -115,8 +116,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -658,8 +659,8 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--INCLUDE
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -676,4 +677,3 @@ INCLUDE
  './INCLUDE/PRED_WINJ_MIN_THP_4A_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_4B_MSW.DATA
+++ b/norne/NORNE_ATW2013_4B_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -113,8 +114,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -125,8 +126,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -671,8 +672,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -693,4 +693,3 @@ INCLUDE
  './INCLUDE/PRED_WINJ_MIN_THP_4B_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_4B_STDW.DATA
+++ b/norne/NORNE_ATW2013_4B_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -109,8 +110,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -121,8 +122,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -665,8 +666,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -687,4 +687,3 @@ INCLUDE
  './INCLUDE/PRED_WINJ_MIN_THP_4B_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_4C_MSW.DATA
+++ b/norne/NORNE_ATW2013_4C_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -117,8 +118,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -129,8 +130,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
---OPTIONS
---77* 1 /
+----OPTIONS
+----77* 1 /
 --
 
 ---------------------------------------------------------
@@ -677,8 +678,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
---INCLUDE
---'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+----'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -700,4 +700,3 @@ INCLUDE
  './INCLUDE/PRED_WINJ_MIN_THP_4C_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_4C_STDW.DATA
+++ b/norne/NORNE_ATW2013_4C_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -110,8 +111,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -122,8 +123,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -666,8 +667,8 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--INCLUDE
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -689,4 +690,3 @@ INCLUDE
  './INCLUDE/PRED_WINJ_MIN_THP_4C_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_4D_MSW.DATA
+++ b/norne/NORNE_ATW2013_4D_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -116,8 +117,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -128,8 +129,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -675,8 +676,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -698,4 +698,3 @@ INCLUDE
  './INCLUDE/PRED_WINJ_MIN_THP_4D_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_4D_STDW.DATA
+++ b/norne/NORNE_ATW2013_4D_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -111,8 +112,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -123,8 +124,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -666,8 +667,8 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--INCLUDE
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -689,4 +690,3 @@ INCLUDE
  './INCLUDE/PRED_WINJ_MIN_THP_4D_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_4E_MSW.DATA
+++ b/norne/NORNE_ATW2013_4E_MSW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -117,8 +118,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -129,8 +130,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -677,8 +678,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -704,4 +704,3 @@ INCLUDE
  './INCLUDE/PRED_WINJ_MIN_THP_4D_MSW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_4E_STDW.DATA
+++ b/norne/NORNE_ATW2013_4E_STDW.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -119,8 +120,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -131,8 +132,8 @@ UNIFOUT
 --FMTOUT
 --FMTIN
 
-OPTIONS
-77* 1 /
+--OPTIONS
+--77* 1 /
 
 ---------------------------------------------------------
 --
@@ -675,8 +676,7 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
-INCLUDE
-'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+--'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 
 GRUPTREE 
@@ -702,4 +702,3 @@ INCLUDE
  './INCLUDE/PRED_WINJ_MIN_THP_4D_STDW.SCH' / 
 
 
-END

--- a/norne/NORNE_ATW2013_B1H_RE-PERF.DATA
+++ b/norne/NORNE_ATW2013_B1H_RE-PERF.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -104,8 +105,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -639,12 +640,10 @@ ZIPPY2
 
 -- PI reduction in case of water cut
 -- Not supported in OPM Flow
---INCLUDE
---'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+----'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 -- Schedule including only well B-1H with re-perforations
 INCLUDE
  './INCLUDE/B1H_RE-PERF.SCH' /
 
 
-END

--- a/norne/NORNE_ATW2013_RESTART.DATA
+++ b/norne/NORNE_ATW2013_RESTART.DATA
@@ -1,3 +1,4 @@
+
 -- This reservoir simulation deck is made available under the Open Database
 -- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
 -- individual contents of the database are licensed under the Database Contents
@@ -96,8 +97,8 @@ VFPPDIMS
 FAULTDIM
 10000 /
 
-PIMTDIMS
-1  51 /
+--PIMTDIMS
+--1 51 /
 
 NSTACK
  30 /
@@ -630,11 +631,10 @@ ZIPPY2
 'SIM=4.2' 'MINSTEP=1E-6' /
 
 -- PI reduction in case of water cut
---INCLUDE
---'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
+----INCLUDE
+----'./INCLUDE/PI/pimultab_low-high_aug-2006.inc' / 
 
 -- History
 INCLUDE
 './INCLUDE/BC0407_RESTART.SCH' / 
 
-END


### PR DESCRIPTION
Hello everyone,

The unsupported keyword OPTIONS and the keyword PIMULTAB were being used in Norne cases. I commented these keywords and the PIMULTAB related keyword PIMTDIMS.

Here is the error message screenshot that I got before comment there keywords.
![1A_STDW](https://github.com/user-attachments/assets/9f219555-4987-475f-929a-95f10ad0c47d)

Flow version 2024.10-pre
