### PR TITLE
Reduce stepsize in 9_3D_GINJ_GAS_MAX_EXPORT_MSW for after May, 20th 2019

### DIFF
--- a/model2/9_3D_GINJ_GAS_MAX_EXPORT_MSW.DATA
+++ b/model2/9_3D_GINJ_GAS_MAX_EXPORT_MSW.DATA
@@ -487,6 +487,9 @@ DATES   -- 11
  20 'MAY' 2019 /
 /
 
+NEXTSTEP
+2    NO / 
+
 -- loosing injector INJ1, only remaining injector is INJ2
 WELOPEN
  'INJ1' 'SHUT' /


### PR DESCRIPTION
to better compare the test compareECLFiles_flow+9_3D_GINJ_GAS_MAX_EXPORT_MSW for https://github.com/OPM/opm-simulators/pull/5741