### PR TITLE
add RESIDUAL to test output

### DIFF
--- a/editnnc/NNC_AND_EDITNNC.DATA
+++ b/editnnc/NNC_AND_EDITNNC.DATA
@@ -210,7 +210,7 @@ RPTSOL
 SWAT FIP=3 THPRES EQUIL RECOV FIPRESV /
 
 RPTRST
- BASIC=2 /
+ BASIC=2 RESIDUAL /
 
 EQUIL
 -- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd


### PR DESCRIPTION
It was discovered that there are no regression tests with RESIDUAL output. This remedies that.