### PR TITLE
Move date of ACTIONx for WCONINJH away from end of report step.

### DIFF
--- a/actionx/ACTIONX_WCONINJH.DATA
+++ b/actionx/ACTIONX_WCONINJH.DATA
@@ -378,7 +378,7 @@ WCONINJH
 
 ACTIONX
     WIWI01   1 /
-    DAY  >=   5 AND /
+    DAY  >=   7 AND /
     MNTH >=  JAN AND /
     YEAR >= 2018 /
 /


### PR DESCRIPTION
This will tests the action in a normal time step (Jan 7. Previously the ACTIONX was triggered at a report step (Jan 5)