### PR TITLE
Remove FIP output from testcase.

### DIFF
--- a/parallel_fieldprops/3D_TRAN_OPERATOR.DATA
+++ b/parallel_fieldprops/3D_TRAN_OPERATOR.DATA
@@ -148,7 +148,7 @@ SOLUTION
 
 
 RPTRST
-  'BASIC = 2' 'PBPD' 'FIP' /
+  'BASIC = 2' 'PBPD' /
 
 EQUIL
 -- Datum    P     woc       Pc   goc     Pc  Rsvd  Rvvd


### PR DESCRIPTION
The FIP triggers test failures for differences of less than 1 m^3 in surface volumes, which in reservoir volumes is about two orders of magnitude smaller, so compared to the cell's pore volume it is very small. Any significant differences will be seen in SGAS.

Discovered while working on the LiveOilPvt bugfix https://github.com/OPM/opm-common/pull/4668.