### PR TITLE
adding .pre-commit-config.yaml for opm-tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+# Pre-commit configuration for OPM-tests
+# This configuration uses the pre-commit framework to automatically format source files
+# before commits, ensuring consistent code style across the project.
+#
+# Installation:
+# -------------
+# 1. Install pre-commit (choose one method):
+#    - Via pip: pip install pre-commit
+#    - Via conda: conda install -c conda-forge pre-commit
+#    - Via homebrew (macOS): brew install pre-commit
+#    - Via package manager (Ubuntu/Debian): apt install pre-commit
+#
+# 2. Install the hooks in your local repository:
+#    pre-commit install
+#
+# Usage:
+# ------
+# - Hooks run automatically on every commit
+# - To run manually on all files: pre-commit run --all-files
+# - To run on specific files: pre-commit run --files <file1> <file2>
+# - To skip hooks for a commit: git commit --no-verify
+# - To update hook versions: pre-commit autoupdate
+#
+# What these hooks do:
+# -------------------
+# - trailing-whitespace: Removes trailing whitespace from lines
+#   (preserves Markdown hard line breaks with --markdown-linebreak-ext=md)
+# - end-of-file-fixer: Ensures files end with exactly one newline
+#
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0  # Latest release as of August 2025
+    hooks:
+      - id: trailing-whitespace
+        files: '\.(?:DATA|data|INC|inc|param|sh|SCH|sch(?:[1-6])?|sched|md|yaml)$'
+        args: [--markdown-linebreak-ext=md]
+        exclude: '^(\.git/)'
+
+      - id: end-of-file-fixer
+        files: '\.(?:DATA|data|INC|inc|param|sh|SCH|sch(?:[1-6])?|sched|md|yaml)$'
+        exclude: '^(\.git/)'


### PR DESCRIPTION
limiting the files to be with certain extensions
files: '\.(?:DATA|data|INC|inc|param|sh|SCH|sch(?:[1-6])?|sched|md|yaml)$'

The following are all the extensions exisiting in the opm-tests.

Likely ASCII: DATA, data, dat, INC, inc, INCL, GRDECL, grdecl, grid, gridopts, Ecl, ecl, CFG, CMD, dimens, done, eqldims, eqlnum, equil, faults, fipnum, fipzon, gitignore, LGR, LOG, multnum, multregt, ntg, param, perm, permx, poro, prop, prpecl, pvt, pvtnum, regdims, relperm1, relperm2, sch, SCH, sch1..sch6, sched, RFT, PRT, thpres, trans, swatinit, tabdims, txt, vfp, VFP, vfpprod, md, yaml, xml, py, sh.
Likely binary/artifacts to exclude: INIT, UNRST, SMSPEC, UNSMRY, RSSPEC, EGRID, DBG, DEBUG, MSG, RSM, INSPEC, ECLRUN, ECLEND, smry, summary*, images jpg, png, docs pdf, h5, odp.