### PR TITLE
Test for handling non-feasible group-target

### DIFF
--- a/gconprod/T1FALLBACK.DATA
+++ b/gconprod/T1FALLBACK.DATA
@@ -5,10 +5,10 @@
 
 -- Copyright (C) 2024 Equinor
 
--- This deck is testing situation where a group switches to a control mode (water)
--- which is not feasible for one of its wells (B2). In this case, the well rather gets
--- a translated target for the original control mode (to prevent singularities)
--- NOTE: this way of handling water-breakthrough is discouraged, but should still 
+-- This deck tests the situation where a group switches to a water control mode
+-- that is not feasible for one of its wells (B-2H). In this case, the well instead
+-- gets a translated target for the original control mode (to prevent singularities).
+-- NOTE: this way of handling water breakthrough is discouraged, but it should still 
 -- be handled gracefully by the simulator.
 -- GCONPROD
 --  'PLAT-A'  ORAT  6000.0 500.0 1*  10000 'RATE' /
@@ -217,7 +217,7 @@ RPTRST
 WELSPECS
 --WELL     GROUP  IHEEL JHEEL   DREF PHASE   DRAD INFEQ SIINS XFLOW PRTAB  DENS
  'B-1H'  'B1'   11    3      1*   OIL     1*   1*   SHUT 1* 1* 1* /
- 'B-2H'  'B1'    4    7      1*   OIL     1*   1*   SHUT 1* 1* 1* /
+ 'B-2H'  'B1'    1    1      1*   OIL     1*   1*   SHUT 1* 1* 1* /
  'B-3H'  'B1'   11   12      1*   OIL     1*   1*   SHUT 1* 1* 1* /
  'C-1H'  'C1'   13   20      1*   OIL     1*   1*   SHUT 1* 1* 1* /
  'C-2H'  'C1'   12   27      1*   OIL     1*   1*   SHUT 1* 1* 1* /

--- a/gconprod/T1FALLBACK.DATA
+++ b/gconprod/T1FALLBACK.DATA
@@ -1,0 +1,294 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2024 Equinor
+
+-- This deck is testing situation where a group switches to a control mode (water)
+-- which is not feasible for one of its wells (B2). In this case, the well rather gets
+-- a translated target for the original control mode (to prevent singularities)
+-- NOTE: this way of handling water-breakthrough is discouraged, but should still 
+-- be handled gracefully by the simulator.
+-- GCONPROD
+--  'PLAT-A'  ORAT  6000.0 500.0 1*  10000 'RATE' /
+--/
+
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+DIMENS
+ 20 30 10 /
+
+OIL
+WATER
+GAS
+DISGAS
+
+ENDSCALE
+/
+
+METRIC
+
+START
+ 01 'JAN' 2020 /
+
+
+EQLDIMS
+ 1 1*  25 /
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   3          2       1*            1    /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  1          1      150          60         3         60 /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10         15            9          10   /
+
+
+UNIFIN
+UNIFOUT
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+ 0  1 /
+
+--
+GRIDUNIT
+ METRES  /
+
+--
+INIT
+
+INCLUDE
+ 'include/test1_20x30x10.grdecl' /
+
+INCLUDE
+ 'include/permx_model5.grdecl' /
+ 
+
+PORO
+ 6000*0.28 / 
+
+COPY
+  PERMX PERMY /
+  PERMX PERMZ /
+/
+
+MULTIPLY
+  PERMZ 0.1 /
+/ 
+
+RPTGRID
+ 'ALLNNC' /
+
+EQUALS
+  'MULTY'  0.01 1 20  14 14  1 10 /
+/
+
+
+------------------------------------------------------------------------------------------------
+EDIT
+------------------------------------------------------------------------------------------------
+
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/pvt_live_oil_dgas.ecl' /
+
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm.inc' /
+-- setting connate water 0.0 (triggers singularity without use of fallback group-target) 
+SWL 
+  6000*0.0 /
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+EQLNUM
+ 6000*1 /
+
+EQUALS
+  FIPNUM  1  1 20   1 14  1 10 /
+  FIPNUM  2  1 20  15 30  1 10 /
+/ 
+
+SATNUM
+ 6000*1 /
+
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+EQUIL
+-- Datum    P     woc     Pc   goc    Pc  Rsvd  Rvvd
+ 2000.00  235.0  2070     0.0  500.00  0.0   1   0   0 /
+
+PBVD
+  2000.00    75.00
+  2150.00    75.00  /
+
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/summary.inc' /
+
+
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+--
+--                                       FIELD
+--                                         |
+--                                       PLAT-A
+--                          ---------------+---------------------
+--                         |                                    |
+--                        M5S                                  M5N
+--                ---------+----------                     -----+-------
+--               |                   |                    |            |
+--              B1                  G1                   C1           F1
+--           ----+------          ---+---              ---+---       ---+---
+--          |    |     |         |      |             |      |      |      |
+--        B-1H  B-2H  B-3H     G-3H    G-4H         C-1H   C-2H    F-1H   F-2H
+--
+
+TUNING
+ 0.5 1  /
+ /
+ 2* 50 1*  20 /
+
+
+GRUPTREE
+ 'PLAT-A' 'FIELD' /
+
+ 'M5S'    'PLAT-A'  /
+ 'M5N'    'PLAT-A'  /
+
+ 'C1'     'M5N'  /
+ 'F1'     'M5N'  /
+ 'B1'     'M5S'  /
+ 'G1'     'M5S'  /
+ /
+
+RPTRST
+ 'BASIC=2' /
+
+
+
+
+WELSPECS
+--WELL     GROUP  IHEEL JHEEL   DREF PHASE   DRAD INFEQ SIINS XFLOW PRTAB  DENS
+ 'B-1H'  'B1'   11    3      1*   OIL     1*   1*   SHUT 1* 1* 1* /
+ 'B-2H'  'B1'    4    7      1*   OIL     1*   1*   SHUT 1* 1* 1* /
+ 'B-3H'  'B1'   11   12      1*   OIL     1*   1*   SHUT 1* 1* 1* /
+ 'C-1H'  'C1'   13   20      1*   OIL     1*   1*   SHUT 1* 1* 1* /
+ 'C-2H'  'C1'   12   27      1*   OIL     1*   1*   SHUT 1* 1* 1* /
+/
+
+WELSPECS
+ 'F-1H'  'F1'   19    4      1*   WATER   1*   1*   SHUT 1* 1* 1* /
+ 'F-2H'  'F1'   19   12      1*   WATER   1*   1*   SHUT 1* 1* 1* /
+ 'G-3H'  'G1'   19   21      1*   WATER   1*   1*   SHUT 1* 1* 1* /
+ 'G-4H'  'G1'   19   25      1*   WATER   1*   1*   SHUT 1* 1* 1* /
+/
+
+COMPDAT
+--WELL      I   J    K1   K2 OP/SH  SATN    TRAN    WBDIA    KH     SKIN DFACT   DIR    PEQVR
+ 'B-1H'    11   3    1    5   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'B-2H'     1   1    1    3   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'B-3H'    11  12    1    4   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'C-1H'    13  20    1    4   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'C-2H'    12  27    1    5   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+/
+
+COMPDAT
+ 'F-1H'    19   4    6   10   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'F-2H'    19  12    6   10   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'G-3H'    19  21    6   10   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'G-4H'    19  25    6   10   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+/
+
+WCONPROD
+--  Well_name  Status  Ctrl  Orate   Wrate  Grate Lrate   RFV  FBHP   WHP  VFP Glift
+   'B-1H'      OPEN    ORAT  1500.0  1*     1*    3000.0  1*   100.0  1*   1*	1*  /
+   'B-2H'      OPEN    ORAT  2500.0  1*     1*    3000.0  1*   100.0  1*   1*	1*  /
+   'B-3H'      OPEN    ORAT  1500.0  1*     1*    3000.0  1*   100.0  1*   1*	1*  /
+   'C-2H'      OPEN    ORAT  1500.0  1*     1*    3000.0  1*   100.0  1*   1*	1*  /
+   'C-1H'      OPEN    ORAT  1500.0  1*     1*    3000.0  1*   100.0  1*   1*	1*  /
+/
+
+GCONINJE
+ 'FIELD'   'WATER'   'RATE'  3500  3*  'NO'  5* /
+/
+
+GCONPROD
+ 'PLAT-A'  ORAT  6000.0 500.0 1*  10000 'RATE' /
+/
+ 
+
+WCONINJE
+-- Well_name    Type    Status  Ctrl    SRate1  Rrate   BHP     THP     VFP
+  'F-1H'        WATER   OPEN    GRUP    4000    1*      500.0    1*      1*     /
+  'F-2H'        WATER   OPEN    GRUP    4000    1*      500.0    1*      1*     /
+  'G-3H'        WATER   OPEN    GRUP    4000    1*      500.0    1*      1*     /
+  'G-4H'        WATER   OPEN    GRUP    4000    1*      500.0    1*      1*     /
+/
+
+TSTEP
+ 0.5 /
+
+
+DATES
+ 1 FEB 2020 /
+/
+
+
+DATES
+ 1 MAR 2020 /
+/
+
+
+DATES
+ 1 APR 2020 /
+ 1 MAY 2020 /
+/
+
+END


### PR DESCRIPTION
Test for situation where a group switches to a control mode that is not feasible for one of its wells. It's a slight modification of the existing cases in the gconprod-folder, and set up such that group PLAT-A switches to WRAT-control while one of its wells (B2) has approx zero water potential (resulting in singularities). This is fixed with https://github.com/OPM/opm-simulators/pull/6963.

The following is a comparison of master with https://github.com/OPM/opm-simulators/pull/6963 for the test (oil-rate for B2, water-rate for PLAT-A which has water-limit 500) 

<img width="350" height="270" alt="image" src="https://github.com/user-attachments/assets/a101cee7-1774-42b5-8651-ab9a256dc246" /> <img width="350" height="270" alt="image" src="https://github.com/user-attachments/assets/bbbe4214-85b4-4570-8dba-ea5b4799cd5d" />

