### PR TITLE
Add satellite RESTART tests

### DIFF
--- a/satellite/GSATPROD2_RESTART.DATA
+++ b/satellite/GSATPROD2_RESTART.DATA
@@ -1,0 +1,277 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2024 Equinor
+
+--==============================================================================
+--		Synthetic reservoir simulation model Box (2021)
+--==============================================================================
+
+
+-- GSATPROD1.DATA + GCONPROD with ORAT to check interaction with group rate control
+
+--------------------------------------------------------------------------------
+--RUNSPEC SECTION
+--------------------------------------------------------------------------------
+
+RUNSPEC
+
+-- Simulation run title
+TITLE
+Simple 2D box model
+
+NOECHO
+
+-- Simulation grid dimension (Imax, Jmax, Kmax)
+DIMENS
+    31  1   31  /
+
+-- Simulation run start
+START
+ 1 JAN 2000 /
+
+--Activates data check only option
+-- NOSIM
+
+-- Fluid phases present
+OIL
+GAS
+DISGAS
+VAPOIL
+WATER
+
+-- type     rock   water
+--          n tab  induction
+ROCKCOMP
+  'REVERS'   1      'NO'    /
+
+-- Measurement unit used
+METRIC
+
+GRIDOPTS
+   'YES'      1*       /
+
+TABDIMS
+            1      1       60     130      1*      100      1*    1* /          
+
+--Regions dimension data
+REGDIMS
+-- NTFIP NMFIPR NRFREG NTFREG
+    1    1      0      0      /
+
+--Dimension for well data
+WELLDIMS
+ 100  100 100 100 /
+
+-- Input and output files format
+UNIFIN
+UNIFOUT
+
+-------------------------------------------------------------------------
+--GRID SECTION
+-------------------------------------------------------------------------
+
+GRID
+
+--Disable echoing of the input file  
+NOECHO
+
+--Requests output of an INIT file
+INIT
+
+--Control output of the Grid geometry file
+GRIDFILE
+  1 1  /
+
+--Message print and stop limits
+MESSAGES
+ 1* 1* 1* 1000 1* 1* 1* 1* 1000000 10000 0 /
+
+NOECHO
+
+--Include simulation grid
+INCLUDE
+  'include/tilted.grdecl' /
+
+EQUALS
+  PORO   0.2  1 31  1 1  1 31 /
+  PERMX   50  1 31  1 1  1 31 /
+  NTG    1.0  1 31  1 1  1 31 /
+/
+
+COPY
+  PERMX PERMY /
+  PERMX PERMZ /
+/
+
+--Set Kv to Kh ratio 
+MULTIPLY
+ PERMZ   1.0e-1   /
+/
+
+-------------------------------------------------------------------------
+--EDIT SECTION
+-------------------------------------------------------------------------
+
+EDIT
+
+------------------------------------------------------------------------
+--PROPS SECTION
+-------------------------------------------------------------------------
+
+PROPS
+
+INCLUDE
+ 'include/global.sgof.inc' /
+
+INCLUDE
+ 'include/global.swof.inc' /
+
+-- Include PVT data
+INCLUDE
+  'include/opm.global.pvt.inc' /
+
+INCLUDE
+  'include/global.pvtw.inc' /
+
+INCLUDE
+ 'include/global.rocktab.inc'  /
+
+------------------------------------------------------------------------
+--REGIONS SECTION
+------------------------------------------------------------------------
+
+REGIONS
+
+EQUALS
+  FIPNUM      1    1 31  1 1  1 31 /
+  SATNUM      1    1 31  1 1  1 31 /
+  PVTNUM      1    1 31  1 1  1 31 /
+/
+
+-------------------------------------------------------------------------
+--SOLUTION SECTION
+-------------------------------------------------------------------------
+
+SOLUTION
+
+RESTART
+  'GSATPROD2'  5  1*  1* /
+
+RPTRST
+  BASIC=2 FLOWS /
+
+------------------------------------------------------------------------
+--SUMMARY SECTION
+------------------------------------------------------------------------
+
+SUMMARY
+
+WGPR
+/
+
+WOPR
+/
+
+WWPR
+/
+WGOR
+/
+
+WWCT
+/
+
+WBHP
+/
+
+GGPR
+/
+
+GOPR
+/
+
+GWPR
+/
+
+FPR
+
+FGPR
+
+FWPR
+
+FOPR
+
+FGOR
+
+FWCT
+
+-------------------------------------------------------------------------
+--SCHEDULE SECTION
+-------------------------------------------------------------------------
+
+SCHEDULE
+
+SKIPREST
+
+RPTRST
+  ALLPROPS BASIC=2 FLOWS /
+
+-- TUNING
+--  1.0  1.0  0.01 6*  1 /
+--  1* 0.0001 1* 0.00001 1* 0.001 1* 0.0001 /
+--  24  1  50  1  50  50   /
+
+GRUPTREE
+  A  FIELD /
+  B  FIELD /
+  WELL  A  /
+  SAT   B  /
+/
+
+WELSPECS
+--WELL     GROUP     IHEEL JHEEL       DREF PHASE       DRAD INFEQ SIINS XFLOW PRTAB  DENS
+ 'PROD'   'WELL'       15     1        0.0   GAS         1*    1*  SHUT   YES    1*    1* /
+/
+
+COMPDAT
+--WELL    I     J    K1    K2 OP/SH  SATN       TRAN      WBDIA         KH       SKIN DFACT   DIR      PEQVR
+------------------------------------------------------------------------------------------------------------
+ 'PROD'  15     1     1    13  OPEN    1*         1*      0.216         1*          0    1*     Z         1* /
+/
+
+WCONPROD
+--WELL   OP/SH   CTL       ORAT       WRAT       GRAT       LRAT       RRAT        BHP        THP   VFP        ALQ
+ 'PROD'   OPEN  GRAT         1*       1000     500000         1*         1*         1*         1*    1*         1* /
+/
+
+GSATPROD
+-- GROUP     OIL   WAT       GAS   RESVOL   GL   CAL
+     SAT  1000.0 500.0 1000000.0       1*   1*    1* /
+/
+GCONPROD
+ 'FIELD' 'ORAT' 2500 /
+/
+
+TSTEP
+ 10*1.0 /
+
+UDQ
+ASSIGN GUOIL SAT 2000.0 /
+ASSIGN GUWAT SAT 1000.0 /
+ASSIGN GUGAS SAT 2000000.0 /
+UNITS  GUOIL SM3/DAY /
+UNITS  GUWAT SM3/DAY /
+UNITS  GUGAS SM3/DAY /
+/
+
+GSATPROD
+-- GROUP     OIL   WAT   GAS   RESVOL   GL   CAL
+     SAT   GUOIL GUWAT GUGAS       1*   1*    1* /
+/
+
+TSTEP
+ 10*1.0 /
+
+END

--- a/satellite/GSATPROD2_RESTART.DATA
+++ b/satellite/GSATPROD2_RESTART.DATA
@@ -3,14 +3,17 @@
 -- individual contents of the database are licensed under the Database Contents
 -- License: http://opendatacommons.org/licenses/dbcl/1.0/
 
--- Copyright (C) 2024 Equinor
+-- Copyright (C) 2026 Equinor ASA
 
 --==============================================================================
 --		Synthetic reservoir simulation model Box (2021)
 --==============================================================================
 
 
--- GSATPROD1.DATA + GCONPROD with ORAT to check interaction with group rate control
+-- This deck is used to test restarting a case with satellite groups.
+--
+-- In this case GSATPROD2.DATA is restarted from step 5 (5 days) with no 
+-- changes to the schedule.  
 
 --------------------------------------------------------------------------------
 --RUNSPEC SECTION

--- a/satellite/GSATPROD6_RESTART.DATA
+++ b/satellite/GSATPROD6_RESTART.DATA
@@ -3,32 +3,12 @@
 -- individual contents of the database are licensed under the Database Contents
 -- License: http://opendatacommons.org/licenses/dbcl/1.0/
 
--- Copyright (C) 2026 Equinor
+-- Copyright (C) 2026 Equinor ASA
 
--- This model is used for testing keyword GSATPROD including Oil, Gas, Water 
--- and Gas Lift Injection rate. The model includes two satellite group. Gas 
--- lift injection is controlled by the gas lift optimization facility. When 
--- gas lift rates are coming in to the model via GSATPROD, gas lift for 
--- group M5N and M5S will be reduced due to maximum gas lift injection rate
--- (GLIFTOPT item 2). 
-
--- Lift Gas from the C-wells and from the satellite SAT2 should enter the 
--- node C1. Lift gas from satellite SAT1 should not enter the node B1, but lift gas 
--- from B-wells should. 
-
--- The production network looks like this. 
-
-
---   o (PLAT-A) --[4]-- +(C1) --- +(C) :  C-1H C-2H
---                      \
---                       --[5]-- +(SAT2) : 
---   \
---    --[5]-- +(B1) --- +(B) :  B-1H B-2H B-3H
---            \
---             --[4]-- +(SAT1) : 
-
-
--- Fixed pressure nodes:  PLAT-A = 21.00
+-- This deck is used to test restarting a case with satellite groups.
+--
+-- In this case GSATPROD6.DATA is restarted from step 4 (1 MAY 2020) with no 
+-- changes to the schedule.  
 
 
 ------------------------------------------------------------------------------------------------

--- a/satellite/GSATPROD6_RESTART.DATA
+++ b/satellite/GSATPROD6_RESTART.DATA
@@ -1,0 +1,382 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2026 Equinor
+
+-- This model is used for testing keyword GSATPROD including Oil, Gas, Water 
+-- and Gas Lift Injection rate. The model includes two satellite group. Gas 
+-- lift injection is controlled by the gas lift optimization facility. When 
+-- gas lift rates are coming in to the model via GSATPROD, gas lift for 
+-- group M5N and M5S will be reduced due to maximum gas lift injection rate
+-- (GLIFTOPT item 2). 
+
+-- Lift Gas from the C-wells and from the satellite SAT2 should enter the 
+-- node C1. Lift gas from satellite SAT1 should not enter the node B1, but lift gas 
+-- from B-wells should. 
+
+-- The production network looks like this. 
+
+
+--   o (PLAT-A) --[4]-- +(C1) --- +(C) :  C-1H C-2H
+--                      \
+--                       --[5]-- +(SAT2) : 
+--   \
+--    --[5]-- +(B1) --- +(B) :  B-1H B-2H B-3H
+--            \
+--             --[4]-- +(SAT1) : 
+
+
+-- Fixed pressure nodes:  PLAT-A = 21.00
+
+
+------------------------------------------------------------------------------------------------
+RUNSPEC
+------------------------------------------------------------------------------------------------
+
+
+DIMENS
+ 20 30 10 /
+
+
+OIL
+WATER
+GAS
+DISGAS
+
+METRIC
+
+START
+ 01 'JAN' 2020 /
+
+--
+GRIDOPTS
+ 'YES'        0 /
+
+EQLDIMS
+ 1 1*  25 /
+
+
+NETWORK
+ 7 6 /
+
+
+REGDIMS
+-- max. ntfip  nmfipr  max. nrfreg   max. ntfreg
+   3          2       1*            2    /
+
+--
+TABDIMS
+--ntsfun     ntpvt  max.nssfun  max.nppvt  max.ntfip  max.nrpvt
+  1          1      150          60         2         60 /
+
+--
+WELLDIMS
+--max.well  max.con/well  max.grup  max.w/grup
+ 10         15            12          10   /
+
+--FLOW   THP  WCT  GCT  ALQ  VFP
+VFPPDIMS
+  22     13   10   13    13   50  /
+
+
+UNIFIN
+UNIFOUT
+
+---------------------------------------------------------------------------
+MESSAGES
+-- --------print limits----------
+-- mess comm  warn    prob  err  bug
+  80000 10000 5000000 5000  300   1
+----------stop limits------------
+-- mess comm  warn    prob  err bug
+  80000 10000 5000000 80000 10   1 /
+
+
+------------------------------------------------------------------------------------------------
+GRID
+------------------------------------------------------------------------------------------------
+
+--
+NEWTRAN
+
+--
+GRIDFILE
+ 0  1 /
+
+--
+GRIDUNIT
+METRES  /
+
+--
+INIT
+
+
+INCLUDE
+ 'include/test1_20x30x10.grdecl' /
+
+
+PORO
+ 6000*0.28 /
+
+PERMX
+ 6000*10000.0 /
+
+PERMZ
+ 6000*1000.0 /
+
+
+COPY
+  PERMX PERMY /
+/
+
+
+RPTGRID
+ 'ALLNNC' /
+
+EQUALS
+  'MULTY'  0.01 1 20  14 14  1 10 /
+/
+
+
+------------------------------------------------------------------------------------------------
+PROPS
+------------------------------------------------------------------------------------------------
+
+NOECHO
+
+INCLUDE
+ 'include/pvt_live_oil_dgas.ecl' /
+
+
+INCLUDE
+ 'include/rock.inc' /
+
+INCLUDE
+ 'include/relperm.inc' /
+
+
+------------------------------------------------------------------------------------------------
+REGIONS
+------------------------------------------------------------------------------------------------
+
+EQLNUM
+ 6000*1 /
+
+FIPNUM
+ 6000*1 /
+
+SATNUM
+ 6000*1 /
+
+
+------------------------------------------------------------------------------------------------
+SOLUTION
+------------------------------------------------------------------------------------------------
+
+
+RPTRST
+  'BASIC = 2' 'PBPD' /
+
+RESTART
+  'GSATPROD6'  4  1*  1* /
+
+
+
+
+------------------------------------------------------------------------------------------------
+SUMMARY
+------------------------------------------------------------------------------------------------
+
+
+INCLUDE
+ 'include/satprod_smry2.inc' /
+
+  
+------------------------------------------------------------------------------------------------
+SCHEDULE
+------------------------------------------------------------------------------------------------
+
+SKIPREST
+
+TUNING
+ 0.5 1.0 /
+/
+/
+
+
+GRUPTREE
+ 'PLAT-A'  'FIELD' /
+
+ 'M5S'    'PLAT-A'  /
+ 'M5N'    'PLAT-A'  /
+
+ 'C1'     'M5N'  /
+ 'SAT2'   'C1'  /
+ 'C'      'C1'  /
+
+ 'B1'     'M5S'  /
+
+ 'B'      'B1'   / 
+ 'SAT1'   'B1'  /
+
+ 'G1'     'M5S'  /
+ 'F1'     'M5N'  /
+
+ /
+
+RPTRST
+ 'BASIC=2' /
+
+
+INCLUDE
+ 'include/well_vfp.ecl' /
+
+INCLUDE
+ 'include/flowl_b_vfp.ecl' /
+
+INCLUDE
+ 'include/flowl_c_vfp.ecl' /
+
+
+WELSPECS
+--WELL     GROUP  IHEEL JHEEL   DREF PHASE   DRAD INFEQ SIINS XFLOW PRTAB  DENS
+ 'B-1H'  'B'   11    3      1*   OIL     1*   1*   SHUT 1* 1* 1* /
+ 'B-2H'  'B'    4    7      1*   OIL     1*   1*   SHUT 1* 1* 1* /
+ 'B-3H'  'B'   11   12      1*   OIL     1*   1*   SHUT 1* 1* 1* /
+ 'C-1H'  'C'   13   20      1*   OIL     1*   1*   SHUT 1* 1* 1* /
+ 'C-2H'  'C'   12   27      1*   OIL     1*   1*   SHUT 1* 1* 1* /
+/
+
+WELSPECS
+ 'F-1H'  'F1'   19    4      1*   WATER   1*   1*   SHUT 1* 1* 1* /
+ 'F-2H'  'F1'   19   12      1*   WATER   1*   1*   SHUT 1* 1* 1* /
+ 'G-3H'  'G1'   19   21      1*   WATER   1*   1*   SHUT 1* 1* 1* /
+ 'G-4H'  'G1'   19   25      1*   WATER   1*   1*   SHUT 1* 1* 1* /
+/
+
+COMPDAT
+--WELL      I   J    K1   K2 OP/SH  SATN    TRAN    WBDIA    KH     SKIN DFACT   DIR    PEQVR
+ 'B-1H'    11   3    1    5   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'B-2H'     4   7    1    6   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'B-3H'    11  12    1    4   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'C-1H'    13  20    1    4   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'C-2H'    12  27    1    5   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+/
+
+COMPDAT
+ 'F-1H'    19   4    6   10   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'F-2H'    19  12    6   10   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'G-3H'    19  21    6   10   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+ 'G-4H'    19  25    6   10   OPEN    1*      1*    0.216    1*        0    1*    Z       1* /
+/
+
+WCONPROD
+--  Well_name  Status  Ctrl  Orate   Wrate  Grate Lrate   RFV  FBHP   WHP  VFP Glift
+   'B-1H'      OPEN    ORAT  4000.0  1*     1*    6000.0  1*   100.0  30   1   1*  /
+   'B-2H'      OPEN    ORAT  4000.0  1*     1*    6000.0  1*   100.0  30   1   1*  /
+   'B-3H'      OPEN    ORAT  4000.0  1*     1*    6000.0  1*   100.0  30   1   1*  /
+   'C-1H'      OPEN    ORAT  4000.0  1*     1*    6000.0  1*   100.0  30   1   1*  /
+   'C-2H'      OPEN    ORAT  4000.0  1*     1*    6000.0  1*   100.0  30   1   1*  /
+/
+
+GCONINJE
+ 'FIELD'   'WATER'    'VREP'  3*      1.020    'NO'  5* /
+/
+
+
+WCONINJE
+-- Well_name    Type    Status  Ctrl    SRate1  Rrate   BHP     THP     VFP
+  'F-1H'        WATER   OPEN    GRUP    4000    1*      225.0    1*      1*     /
+  'F-2H'        WATER   OPEN    GRUP    4000    1*      225.0    1*      1*     /
+  'G-3H'        WATER   OPEN    GRUP    4000    1*      225.0    1*      1*     /
+  'G-4H'        WATER   OPEN    GRUP    4000    1*      225.0    1*      1*     /
+/
+
+BRANPROP
+--  Downtree  Uptree     #VFP    ALQ
+    C1        PLAT-A     4       1* /
+    B1        PLAT-A     5       1* /
+    C         C1      9999       1* /
+    B         B1      9999       1* /
+    SAT1      B1         4       1* /
+    SAT2      C1         5       1* /
+/
+
+NODEPROP
+--  Node_name  Press  autoChoke?  addGasLift?  Group_name
+     PLAT-A    21.0   NO          NO           1*  /
+     B         1*     NO          YES          1*  /
+     B1        1*     NO          NO           1*  /
+     C         1*     NO          YES          1*  /
+     C1        1*     NO          NO           1*  /
+     SAT1      1*     NO          NO           1*  /
+     SAT2      1*     NO          YES          1*  /
+/
+
+
+-- Turns on gas lift optimization
+LIFTOPT
+ 12500 5E-3 0.0 YES /
+
+
+-- Group lift gas limits for gas lift optimization
+GLIFTOPT
+ 'PLAT-A'  150000 /  
+/
+
+GCONPROD
+ 'PLAT-A' ORAT 12000  1*   1000000.0  1*  'RATE' /
+/
+
+-- wells available for gas lift
+-- minimum gas lift rate, enough to keep well flowing
+WLIFTOPT
+ 'B-1H'   YES   150000   1.01   -1.0  /
+ 'B-2H'   YES   150000   1.01   -1.0  /
+ 'B-3H'   YES   150000   1.01   -1.0  /
+ 'C-1H'   YES   150000   1.01   -1.0  /
+ 'C-2H'   YES   150000   1.01   -1.0  /
+/
+
+DATES
+ 1 FEB 2020 /
+ 1 MAR 2020 /
+ 1 APR 2020 /
+/
+
+GSATPROD
+-- GROUP     OIL    WAT       GAS     RESVOL   GL    CAL
+   'SAT1'   522.0   64.0    26100.0     1*   50000     1* /
+   'SAT2'   827.0  235.0    28000.0     1*   33700     1* /
+/
+
+DATES
+ 1 MAY 2020 /
+/
+
+
+GSATPROD
+-- GROUP     OIL    WAT       GAS     RESVOL   GL    CAL
+   'SAT1'   588.0   69.0    31100.0     1*   38000     1* /
+   'SAT2'   777.0  244.0    27400.0     1*   31700     1* /
+/
+
+DATES 
+ 1 JUN 2020 /
+/
+
+GSATPROD
+-- GROUP     OIL    WAT       GAS     RESVOL   GL    CAL
+   'SAT1'   348.0   94.0    23430.0     1*   23000     1* /
+   'SAT2'   667.0  314.0    21430.0     1*   17700     1* /
+/
+
+DATES 
+ 1 JUL 2020 /
+ 1 AUG 2020 /
+/
+
+END
+


### PR DESCRIPTION
GSATPROD2_RESTART - Restarts GSATPROD2 at restart 5 with no changes to the Schedule.
GSATPROD6_RESTART - Restarts GSATPROD6 at restart 6 with no changes to the Schedule.

Both of these cases currently fail with flow 2026.04, for example:

```
Error: Unrecoverable errors while loading input:
unordered_map::at
```

See [opm-simulators#7058](https://github.com/OPM/opm-simulators/pull/7058).