### PR TITLE
lgr: unrefined twin deck for a field-totals comparison

### DIFF
--- a/lgr/SPE1CASE1_CARFIN1-3DCORNERPOINT_XYZ_NOLGR.DATA
+++ b/lgr/SPE1CASE1_CARFIN1-3DCORNERPOINT_XYZ_NOLGR.DATA
@@ -107,10 +107,9 @@ RPTGRIDL
   'TRANY' 
   'TRANZ'
  / 
-CARFIN
--- NAME I1-I2 J1-J2 K1-K2 NX NY NZ
-'LGR1'  6  6  6  6  1  3  2  2  6 /
-ENDFIN
+-- No refinement.  Unrefined twin of SPE1CASE1_CARFIN1-3DCORNERPOINT_XYZ:
+-- refining the grid must not change the field totals, which is what the
+-- comparison test asserts.
 
 
 RPTGRIDL

--- a/lgr/SPE1CASE1_CARFIN1-3DCORNERPOINT_XYZ_NOLGR.DATA
+++ b/lgr/SPE1CASE1_CARFIN1-3DCORNERPOINT_XYZ_NOLGR.DATA
@@ -8,8 +8,11 @@
 -- This simulation is based on the data given in 'Comparison of Solutions to a Three-Dimensional
 -- Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh, Journal of Petroleum Technology, January 1981
 
--- Test case for LGR grid,  CARFIN and ENDFIN keyword are used. 
---3D CORNER POINT CASE WITH NON-ACTIVE CELL, LGR on grids 6,6,1:3 and non-active cells are 6,5,1:3
+-- Unrefined reference for SPE1CASE1_CARFIN1-3DCORNERPOINT_XYZ.  No local grid
+-- refinement: the two decks are identical apart from the CARFIN block, so the
+-- field totals they report must agree.  That is what the comparison test
+-- asserts, and it is the only reason this deck exists.
+--3D CORNER POINT CASE WITH NON-ACTIVE CELL, non-active cells are 6,5,1:3
 
 ---------------------------------------------------------------------------
 ------------------------ SPE1 - CASE 1 ------------------------------------


### PR DESCRIPTION
Adds `lgr/SPE1CASE1_CARFIN1-3DCORNERPOINT_XYZ_NOLGR.DATA`: the existing `..._XYZ` deck with the `CARFIN` block removed and nothing else changed. Both decks gain `FOIP`/`FGIP`/`FWIP`/`FRPV`/`FHPV` (the refined one already asked for `FPR`).

Refining part of the grid must not change the field totals, so the pair can be compared against each other — no reference data, and nothing existing is perturbed (the `..._XYZ` deck is not currently used by any test).

The companion test is OPM/opm-simulators#7315. Measured with both decks on the fixes in #7245 + #7244:

| | refined | unrefined |
|---|---|---|
| FPR | 4992.268066 | 4992.268066 |
| FOIP | 8.513534e+07 | 8.513534e+07 |
| FGIP | 1.081219e+08 | 1.081219e+08 |
| FRPV | 1.832981e+08 | 1.832981e+08 |
| FHPV | 1.429725e+08 | 1.429725e+08 |

On current master every one of these is **0** for the refined deck — all cell-based output is dropped when an LGR is present.